### PR TITLE
G4CMP-9

### DIFF
--- a/library/include/G4CMPMeshElectricField.hh
+++ b/library/include/G4CMPMeshElectricField.hh
@@ -35,8 +35,8 @@ public:
   G4CMPMeshElectricField& operator=(const G4CMPMeshElectricField &p);
 
   // Sorting operator (compares x, y, z in sequence)
-  static G4bool vector_comp(const std::vector<G4double>& p1,
-			    const std::vector<G4double>& p2);
+  static G4bool vector_comp(const std::array<G4double, 4>& p1,
+          const std::array<G4double, 4>& p2);
 
 private:
   G4CMPTriLinearInterp Interp;

--- a/library/include/G4CMPTriLinearInterp.hh
+++ b/library/include/G4CMPTriLinearInterp.hh
@@ -12,18 +12,19 @@
 #include "G4ThreeVector.hh"
 #include <vector>
 #include <map>
+#include <array>
 
 
 class G4CMPTriLinearInterp {
 public:
   G4CMPTriLinearInterp() : TetraIdx(0) {;}	// Uninitialized version
 
-  G4CMPTriLinearInterp(const std::vector<std::vector<G4double> >& xyz,
+  G4CMPTriLinearInterp(const std::vector<std::array<G4double, 3> >& xyz,
 		       const std::vector<G4double>& v);
   ~G4CMPTriLinearInterp() {;}
 
   // User initialization or re-initialization
-  void UseMesh(const std::vector<std::vector<G4double> >& xyz,
+  void UseMesh(const std::vector<std::array<G4double, 3> >& xyz,
 	       const std::vector<G4double>& v);
   
   G4double GetPotential(const G4double pos[3]) const;
@@ -31,10 +32,10 @@ public:
   
 private:
   std::map<G4int,G4int> qhull2x;
-  std::vector<std::vector<G4double> > X;
+  std::vector<std::array<G4double, 3> > X;
   std::vector<G4double> V;
-  std::vector<std::vector<G4int> > Tetrahedra;
-  std::vector<std::vector<G4int> > Neighbors;
+  std::vector<std::array<G4int, 4> > Tetrahedra;
+  std::vector<std::array<G4int, 4> > Neighbors;
   mutable G4int TetraIdx;
 
   void BuildTetraMesh();	// Builds mesh from pre-initialized 'X' array

--- a/library/include/G4CMPTriLinearInterp.hh
+++ b/library/include/G4CMPTriLinearInterp.hh
@@ -14,17 +14,18 @@
 #include <map>
 #include <array>
 
+using point = std::array<G4double, 3>;
 
 class G4CMPTriLinearInterp {
 public:
   G4CMPTriLinearInterp() : TetraIdx(0) {;}	// Uninitialized version
 
-  G4CMPTriLinearInterp(const std::vector<std::array<G4double, 3> >& xyz,
+  G4CMPTriLinearInterp(const std::vector<point >& xyz,
 		       const std::vector<G4double>& v);
   ~G4CMPTriLinearInterp() {;}
 
   // User initialization or re-initialization
-  void UseMesh(const std::vector<std::array<G4double, 3> >& xyz,
+  void UseMesh(const std::vector<point >& xyz,
 	       const std::vector<G4double>& v);
   
   G4double GetPotential(const G4double pos[3]) const;
@@ -32,7 +33,7 @@ public:
   
 private:
   std::map<G4int,G4int> qhull2x;
-  std::vector<std::array<G4double, 3> > X;
+  std::vector<point > X;
   std::vector<G4double> V;
   std::vector<std::array<G4int, 4> > Tetrahedra;
   std::vector<std::array<G4int, 4> > Neighbors;

--- a/library/include/G4CMPTriLinearInterp.hh
+++ b/library/include/G4CMPTriLinearInterp.hh
@@ -37,6 +37,7 @@ private:
   std::vector<std::array<G4int, 4> > Tetrahedra;
   std::vector<std::array<G4int, 4> > Neighbors;
   mutable G4int TetraIdx;
+  mutable G4double tmpField[6];
 
   void BuildTetraMesh();	// Builds mesh from pre-initialized 'X' array
   

--- a/library/src/G4CMPMeshElectricField.cc
+++ b/library/src/G4CMPMeshElectricField.cc
@@ -19,6 +19,7 @@
 #include "G4SystemOfUnits.hh"
 #include <vector>
 #include <fstream>
+#include <array>
 
 using std::vector;
 
@@ -52,9 +53,9 @@ void G4CMPMeshElectricField::BuildInterp(const G4String& EpotFileName) {
     G4cout << G4endl;
   }
 
-  vector<vector<G4double> > tempX;
+  vector<std::array<G4double, 4> > tempX;
 
-  vector<G4double> temp(4, 0);
+  std::array<G4double, 4> temp = {{ 0, 0, 0, 0 }};
   G4double x,y,z,v;
 
   G4double vmin=99999., vmax=-99999.;
@@ -81,7 +82,7 @@ void G4CMPMeshElectricField::BuildInterp(const G4String& EpotFileName) {
 
   std::sort(tempX.begin(),tempX.end(), vector_comp);
 
-  vector<vector<G4double> > X(tempX.size(),vector<G4double>(3,0));
+  vector<std::array<G4double, 3> > X(tempX.size(), {{0,0,0}});
   vector<G4double> V(tempX.size(),0);
 
   for (size_t ii = 0; ii < tempX.size(); ++ii)
@@ -110,8 +111,8 @@ G4double G4CMPMeshElectricField::GetPotential(const G4double Point[4]) const {
 }
 
 
-G4bool G4CMPMeshElectricField::vector_comp(const vector<G4double>& p1,
-					   const vector<G4double>& p2) {
+G4bool G4CMPMeshElectricField::vector_comp(const std::array<G4double, 4>& p1,
+             const std::array<G4double, 4>& p2) {
   if (p1[0] < p2[0])
     return true;
   else if (p2[0] < p1[0])

--- a/library/src/G4CMPTriLinearInterp.cc
+++ b/library/src/G4CMPTriLinearInterp.cc
@@ -20,9 +20,6 @@
 using namespace orgQhull;
 using std::map;
 using std::vector;
-using point = std::array<G4double, 3>;
-
-G4int oldIdx = -9;
 
 
 G4CMPTriLinearInterp::G4CMPTriLinearInterp(const vector<point >& xyz,
@@ -173,27 +170,27 @@ G4double G4CMPTriLinearInterp::GetPotential(const G4double pos[3]) const {
 
 void G4CMPTriLinearInterp::GetField(const G4double pos[4], G4double field[6]) const {
   G4double bary[4];
+  G4int oldIdx = TetraIdx;
   FindTetrahedron(pos, bary);
 
   if (TetraIdx == -1)
-      for (G4int i = 0; i < 6; ++i)
-          field[i] = 0;
+    for (G4int i = 0; i < 6; ++i)
+      field[i] = 0;
   if (oldIdx == TetraIdx)
-      for (G4int i = 0; i < 6; ++i)
-          field[i] = tmpField[i];
+    for (G4int i = 0; i < 6; ++i)
+      field[i] = tmpField[i];
   else {
-      G4double ET[4][3];
-      BuildT4x3(ET);
-      for (G4int i = 0; i < 3; ++i) {
-          field[i] = 0.0;
-          field[3+i] = V[Tetrahedra[TetraIdx][0]]*ET[0][i] +
-                       V[Tetrahedra[TetraIdx][1]]*ET[1][i] +
-                       V[Tetrahedra[TetraIdx][2]]*ET[2][i] +
-                       V[Tetrahedra[TetraIdx][3]]*ET[3][i];
+    G4double ET[4][3];
+    BuildT4x3(ET);
+    for (G4int i = 0; i < 3; ++i) {
+      field[i] = 0.0;
+      field[3+i] = V[Tetrahedra[TetraIdx][0]]*ET[0][i] +
+                   V[Tetrahedra[TetraIdx][1]]*ET[1][i] +
+                   V[Tetrahedra[TetraIdx][2]]*ET[2][i] +
+                   V[Tetrahedra[TetraIdx][3]]*ET[3][i];
       }
-      for (G4int i = 0; i < 6; ++i)
-          tmpField[i] = field[i];
-      oldIdx = TetraIdx;
+    for (G4int i = 0; i < 6; ++i)
+      tmpField[i] = field[i];
   }
 }
 

--- a/library/src/G4CMPTriLinearInterp.cc
+++ b/library/src/G4CMPTriLinearInterp.cc
@@ -22,6 +22,8 @@ using std::map;
 using std::vector;
 using point = std::array<G4double, 3>;
 
+G4int oldIdx = -9;
+
 
 G4CMPTriLinearInterp::G4CMPTriLinearInterp(const vector<point >& xyz,
 					   const vector<G4double>& v)
@@ -174,18 +176,24 @@ void G4CMPTriLinearInterp::GetField(const G4double pos[4], G4double field[6]) co
   FindTetrahedron(pos, bary);
 
   if (TetraIdx == -1)
-    for (G4int i = 0; i < 6; ++i)
-      field[i] = 0;
+      for (G4int i = 0; i < 6; ++i)
+          field[i] = 0;
+  if (oldIdx == TetraIdx)
+      for (G4int i = 0; i < 6; ++i)
+          field[i] = tmpField[i];
   else {
-    G4double ET[4][3];
-    BuildT4x3(ET);
-    for (G4int i = 0; i < 3; ++i) {
-      field[i] = 0.0;
-      field[3+i] = V[Tetrahedra[TetraIdx][0]]*ET[0][i] +
-                   V[Tetrahedra[TetraIdx][1]]*ET[1][i] +
-                   V[Tetrahedra[TetraIdx][2]]*ET[2][i] +
-                   V[Tetrahedra[TetraIdx][3]]*ET[3][i];
-    }
+      G4double ET[4][3];
+      BuildT4x3(ET);
+      for (G4int i = 0; i < 3; ++i) {
+          field[i] = 0.0;
+          field[3+i] = V[Tetrahedra[TetraIdx][0]]*ET[0][i] +
+                       V[Tetrahedra[TetraIdx][1]]*ET[1][i] +
+                       V[Tetrahedra[TetraIdx][2]]*ET[2][i] +
+                       V[Tetrahedra[TetraIdx][3]]*ET[3][i];
+      }
+      for (G4int i = 0; i < 6; ++i)
+          tmpField[i] = field[i];
+      oldIdx = TetraIdx;
   }
 }
 

--- a/library/src/G4CMPTriLinearInterp.cc
+++ b/library/src/G4CMPTriLinearInterp.cc
@@ -15,20 +15,22 @@
 #include <iostream>
 #include <ctime>
 #include <map>
+#include <array>
 
 using namespace orgQhull;
 using std::map;
 using std::vector;
+using point = std::array<G4double, 3>;
 
 
-G4CMPTriLinearInterp::G4CMPTriLinearInterp(const vector<vector<G4double> >& xyz,
+G4CMPTriLinearInterp::G4CMPTriLinearInterp(const vector<point >& xyz,
 					   const vector<G4double>& v)
   : X(xyz), V(v), TetraIdx(0) {
   BuildTetraMesh();
 }
 
 void 
-G4CMPTriLinearInterp::UseMesh(const std::vector<std::vector<G4double> >& xyz,
+G4CMPTriLinearInterp::UseMesh(const std::vector<point >& xyz,
 			      const std::vector<G4double>& v) {
   X = xyz;
   V = v;
@@ -72,10 +74,10 @@ void G4CMPTriLinearInterp::BuildTetraMesh() {
   QhullSet<QhullVertex>::iterator vItr;
   map<G4int, G4int> ID2Idx;
   G4int numTet = 0, j;
-  vector<vector<G4int> > tmpTetrahedra =
-      vector<vector<G4int> >(hull.facetCount(), vector<G4int>(4, 0));
-  vector<vector<G4int> > tmpNeighbors =
-      vector<vector<G4int> >(hull.facetCount(), vector<G4int>(4, -1));
+  vector<std::array<G4int, 4> > tmpTetrahedra =
+          vector<std::array<G4int, 4> >(hull.facetCount(), {{0,0,0,0}});
+  vector<std::array<G4int, 4> > tmpNeighbors =
+          vector<std::array<G4int, 4> >(hull.facetCount(), {{-1,-1,-1,-1}});
   for (fItr = hull.facetList().begin();fItr != hull.facetList().end(); fItr++) {
     facet = *fItr;
     if (!facet.isUpperDelaunay()) {


### PR DESCRIPTION
G4CMPTriLinearInterp now caches the electric field values. It checks against the previous tetrahedra index, and if the current point is not in a new tetrahedra, the cached values are returned. Otherwise, new field values are calculated and stored. Additionally, TriLinearInterp now uses vectors of arrays instead of vectors of vectors.