### PR TITLE
Rename IVRate Model to Matrix

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,7 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 [ Modifications included on branch G4CMP-404, put subtask tags below it: ]
-2025-05-02  G4CMP-404 : Improve charge carriers-phonons scattering.
+2025-05-27  G4CMP-404 : Improve charge carriers-phonons scattering.
+2025-05-27  G4CMP-485 : Rename "IVRate" model name to "Matrix".
 2025-05-02  G4CMP-120 : IV scattering process should include kinematic effects.
 2024-09-27  G4CMP-429 : Add IV order and # final valleys to config.txt.
 2024-09-20  G4CMP-427 : Fix math error in G4LatticeLogical::MapV_elToP.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ developers should check the source code in
 | G4CMP\_USE\_KVSOLVER    | /g4mcp/useKVsolver [t\|f]     | Use eigensolver for K-Vg mapping        |
 | G4CMP\_FANO\_ENABLED    | /g4cmp/enableFanoStatistics [t\|f] | Apply Fano statistics to input ionization |
 | G4CMP\_KAPLAN\_KEEP     | /g4cmp/kaplanKeepPhonons [t\|f] | Reflect or iterate all phonons in KaplanQP |
-| G4CMP\_IV\_RATE\_MODEL  | /g4cmp/IVRateModel [IVRate\|Linear\|Quadratic] | Select intervalley rate parametrization |
+| G4CMP\_IV\_RATE\_MODEL  | /g4cmp/IVRateModel [Matrix\|Linear\|Quadratic] | Select intervalley rate parametrization |
 | G4CMP\_LUKE\_FILE | /g4cmp/LukeDebugFile [S] | LukeScattering debug filename |
 | G4CMP\_ETRAPPING\_MFP   | /g4cmp/eTrappingMFP [L] mm        | Mean free path for electron trapping |
 | G4CMP\_HTRAPPING\_MFP   | /g4cmp/hTrappingMFP [L] mm        | Mean free path for charge hole trapping |
@@ -551,7 +551,7 @@ the crystal system.
 | ivOrder    | val val ... | order of IV process (0th or 1st) | none   |
 | ivFGScat   | str str ... | f or g-type IV scatterging.      | none   |
 | **InterValley scattering  (Linear and Quadratic Models) ** |
-| ivModel     | name | IVRate (matrix), Linear or Quadratic   | string |
+| ivModel     | name| Matrix, Linear or Quadratic             | string |
 | ivLinRate0  | val | Constant term in linear IV expression   | Hz     |
 | ivLinRate1  | val | Linear term in linear IV expression     | Hz     |
 | ivLinPower  | exp | Exponent: rate = Rate0 + Rate1* E^exp   | none   |

--- a/library/src/G4CMPConfigMessenger.cc
+++ b/library/src/G4CMPConfigMessenger.cc
@@ -43,6 +43,7 @@
 // 20240506  G4CMP-371: Add flag to keep or discard below-minimum track energy.
 // 20241224  G4CMP-419: Add macro command to set LukeScattering debug file.
 // 20250212  G4CMP-457: Add macro command for Lindhard empirical ionization model.
+// 20250527  G4CMP-485: Change IVRate name to Matrix.
 
 
 #include "G4CMPConfigMessenger.hh"
@@ -148,10 +149,10 @@ G4CMPConfigMessenger::G4CMPConfigMessenger(G4CMPConfigManager* mgr)
 
   ivRateModelCmd = CreateCommand<G4UIcmdWithAString>("IVRateModel",
            "Set the model for IV scattering rate.");
-  ivRateModelCmd->SetGuidance("IVRate	  : Scattering matrix calculation");
+  ivRateModelCmd->SetGuidance("Matrix	  : Scattering matrix calculation");
   ivRateModelCmd->SetGuidance("Linear	  : Gamma0 + Gamma * E^x");
   ivRateModelCmd->SetGuidance("Quadratic  : Gamma * sqrt[(E0^2 + E^2)^x]");
-  ivRateModelCmd->SetCandidates("IVRate Linear Quadratic");
+  ivRateModelCmd->SetCandidates("Matrix Linear Quadratic");
   ivRateModelCmd->SetDefaultValue("Quadratic");
 
   trapEMFPCmd = CreateCommand<G4UIcmdWithADoubleAndUnit>("eTrappingMFP",

--- a/library/src/G4CMPInterValleyScattering.cc
+++ b/library/src/G4CMPInterValleyScattering.cc
@@ -90,7 +90,7 @@ void G4CMPInterValleyScattering::UseRateModel(G4String model) {
       UseRateModel(new G4CMPIVRateLinear);
       doValleySwitch=true;    // Deprecated IV scattering PostStepDoIt
       }
-  else if (model(0) == 'i') {
+  else if (model(0) == 'm') {
       UseRateModel(new G4CMPInterValleyRate);
       doValleySwitch=false;    // Up-to-date IV scattering PostStepDoIt
       }


### PR DESCRIPTION
I have change the name IVRate to Matrix where needed. I did a test run with the macro command :

`/g4cmp/IVRateModel Matrix`

and it works as expected. I think the branch is ready to be pulled into [G4CMP-404]