### PR TITLE
Protect G4CMPProcessUtils::FillParticleChange with Phonon Check.

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,6 +7,7 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for quasiparticle tracking. New Tags go below this line.
+2025-08-29  G4CMP-497 : Protect FillParticleChange with Phonon Check.
 2025-08-14  G4CMP-219 : Quasiparticle tracking in superconducting films.
 2025-08-14  G4CMP-496 : Fix phonon wavevector & momentum direction from DoDecay.
 2025-08-01  G4CMP-326 : Kill "thermal" phonons in TrackLimiter if temp>0.

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -60,6 +60,7 @@
 // 20250508  Fix local and global coordinate system for phonon wavevectors.
 // 20250512  Use tempvec2 for Vg in LoadDataForTrack to improve performance.
 // 20250814  Add UpdatePhononWavevector() to update phonon wavevector and Vg.
+// 20250829  Protect FillParticleChange with Phonon Check.
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -228,6 +229,8 @@ void G4CMPProcessUtils::FindLattice(const G4VPhysicalVolume* volume) {
 // Wavevector is expected to be in the global coordinate frame
 void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
             const G4Track& track, const G4ThreeVector& wavevector) const {
+  if (!G4CMP::IsPhonon(track)) return;
+
   // Get phonon mode from track
   G4int mode = GetPolarization(track);
 
@@ -245,6 +248,8 @@ void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
 
 void G4CMPProcessUtils::FillParticleChange(G4CMPParticleChangeForPhonon& particleChange,
   const G4Step& step, const G4ThreeVector& position) const {
+    if (!G4CMP::IsPhonon(track)) return;
+
     // Update the local time to account for displacement
     G4double delta_t = (position - *particleChange.GetPosition()).mag() / particleChange.GetVelocity();
     G4StepPoint* postStep = step.GetPostStepPoint();


### PR DESCRIPTION
While reviewing [G4CMP-496](https://jira.slac.stanford.edu/browse/G4CMP-496), we realized the G4CMPProcessUtils::FillParticleChange, which uses phonon specific functions to get the group velocity (and velocity magnitude), does not protect against someone calling this function for electrons. 

We should protect the phonon-specific functions with a "IsPhonon()" if-statement. Return immediately if the particle is a charge.