### PR TITLE
G4CMP-513

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,7 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2025-01-19  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-01-19  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-01-19	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.
 2025-12-09  G4CMP-511 : Create parallel Lambertian reflection code for charges.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,9 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2026-01-19  G4CMP-515 : Expand charge reflection for both specular and diffuse.
-2026-01-19	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-02-05  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-02-05	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-02-05	G4CMP-582 : Make the frequency parameter of RefProb functions optional.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.
 2025-12-09  G4CMP-511 : Create parallel Lambertian reflection code for charges.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2026-02-05  G4CMP-515 : Expand charge reflection for both specular and diffuse.
-2026-02-05	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-02-19  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-02-19	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 2026-02-05	G4CMP-582 : Make the frequency parameter of RefProb functions optional.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2026-02-26  G4CMP-515 : Expand charge reflection for both specular and diffuse.
-2026-02-26	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-02-27  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-02-27	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 2026-02-05	G4CMP-582 : Make the frequency parameter of RefProb functions optional.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2026-02-25  G4CMP-515 : Expand charge reflection for both specular and diffuse.
-2026-02-25	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-02-26  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-02-26	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 2026-02-05	G4CMP-582 : Make the frequency parameter of RefProb functions optional.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2026-02-19  G4CMP-515 : Expand charge reflection for both specular and diffuse.
-2026-02-19	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-02-25  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-02-25	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 2026-02-05	G4CMP-582 : Make the frequency parameter of RefProb functions optional.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
-2026-02-27  G4CMP-515 : Expand charge reflection for both specular and diffuse.
-2026-02-27	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
+2026-03-25  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-03-25	G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 2026-02-05	G4CMP-582 : Make the frequency parameter of RefProb functions optional.
 2026-01-19	G4CMP-514 : Modify G4CMPSurfaceProperty for specular reflection.
 2025-12-15  G4CMP-518 : Make PhononVelocityIsInward() generic.

--- a/examples/charge/single.mac
+++ b/examples/charge/single.mac
@@ -4,6 +4,8 @@
 /g4cmp/producePhonons 0.
 /g4cmp/sampleLuke 0.
 
+/g4cmp/chargeBounces 0 # this command allows you to set the max charge bounces
+
 /run/initialize
 
 /process/setVerbose 1 G4CMPInterValleyScattering

--- a/examples/charge/vis.mac
+++ b/examples/charge/vis.mac
@@ -5,6 +5,8 @@
 /g4cmp/producePhonons 0.
 /g4cmp/sampleLuke 0.
 
+/g4cmp/chargeBounces 0 # this command allows you to set the max charge bounces
+
 /run/initialize
 /vis/open OGL
 /vis/viewer/set/upVector 1 0 0

--- a/library/include/G4CMPDriftBoundaryProcess.hh
+++ b/library/include/G4CMPDriftBoundaryProcess.hh
@@ -30,6 +30,7 @@
 // 20251013  Add functions for specular and diffuse electron reflection.
 // 20251204  G4CMP-511 -- Create parallel Lambertian reflection code for charges.
 // 20251210  G4CMP-518 -- Make PhononVelocityIsInward() generic.
+// 20250219  G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 
 #ifndef G4CMPDriftBoundaryProcess_h
 #define G4CMPDriftBoundaryProcess_h 1
@@ -64,18 +65,11 @@ protected:
   virtual void DoReflection(const G4Track& aTrack,const G4Step& aStep,
 			    G4ParticleChange& aParticleChange);
 
-  virtual void DoReflectionElectron(const G4Track& aTrack,const G4Step& aStep,
-				    G4ParticleChange& aParticleChange);
+  virtual G4ThreeVector DoSpecularReflection(const G4Track& aTrack,const G4Step& aStep);
 
-  virtual G4ThreeVector DoSpecularElectron(const G4ThreeVector& inDir,
-					   const G4ThreeVector& surfNorm,
-					   const G4ThreeVector& surfPos) const;
+  virtual G4ThreeVector DoSpecRefElectron(const G4Track& aTrack,const G4Step& aStep);
 
-  virtual G4ThreeVector DoDiffuseElectron(const G4ThreeVector& surfNorm,
-					  const G4ThreeVector& surfPos) const;
-
-  virtual void DoReflectionHole(const G4Track& aTrack,const G4Step& aStep,
-				G4ParticleChange& aParticleChange);
+  virtual G4ThreeVector DoSpecRefHole(const G4Step& aStep);
 
   // Called when maximum bounces have been recorded; does recombination
   virtual void DoFinalReflection(const G4Track& aTrack,const G4Step& aStep,

--- a/library/include/G4CMPDriftBoundaryProcess.hh
+++ b/library/include/G4CMPDriftBoundaryProcess.hh
@@ -67,9 +67,9 @@ protected:
 
   virtual G4ThreeVector DoSpecularReflection(const G4Track& aTrack,const G4Step& aStep);
 
-  virtual G4ThreeVector DoSpecRefElectron(const G4Track& aTrack,const G4Step& aStep);
+  virtual G4ThreeVector DoSpecularElectron(const G4Track& aTrack,const G4Step& aStep);
 
-  virtual G4ThreeVector DoSpecRefHole(const G4Step& aStep);
+  virtual G4ThreeVector DoSpecularHole(const G4Step& aStep);
 
   // Called when maximum bounces have been recorded; does recombination
   virtual void DoFinalReflection(const G4Track& aTrack,const G4Step& aStep,

--- a/library/include/G4CMPDriftBoundaryProcess.hh
+++ b/library/include/G4CMPDriftBoundaryProcess.hh
@@ -62,14 +62,14 @@ protected:
   virtual void DoAbsorption(const G4Track& aTrack, const G4Step& aStep,
 			    G4ParticleChange& aParticleChange);
 
-  virtual void DoReflection(const G4Track& aTrack,const G4Step& aStep,
+  virtual void DoReflection(const G4Track& aTrack, const G4Step& aStep,
 			    G4ParticleChange& aParticleChange);
 
-  virtual G4ThreeVector DoSpecularReflection(const G4Track& aTrack,const G4Step& aStep);
+  virtual G4ThreeVector DoSpecularReflection(const G4Track& aTrack, const G4Step& aStep);
 
-  virtual G4ThreeVector DoSpecularElectron(const G4Track& aTrack,const G4Step& aStep);
+  virtual G4ThreeVector DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep);
 
-  virtual G4ThreeVector DoSpecularHole(const G4Step& aStep);
+  virtual G4ThreeVector DoSpecularHole(const G4Track& aTrack, const G4Step& aStep);
 
   // Called when maximum bounces have been recorded; does recombination
   virtual void DoFinalReflection(const G4Track& aTrack,const G4Step& aStep,

--- a/library/include/G4CMPSurfaceProperty.hh
+++ b/library/include/G4CMPSurfaceProperty.hh
@@ -12,6 +12,8 @@
 //		probabilities, and computation functions.
 // 20200601  G4CMP-206: Need thread-local copies of electrode pointers
 // 20260105  G4CMP-514: Modify G4CMPSurfaceProperty for specular reflection.
+// 20260205  G4CMP-582: Make the frequency parameter of RefProb functions
+//    in G4CMPSurfaceProperty optional.
 
 #ifndef G4CMPSurfaceProperty_h
 #define G4CMPSurfaceProperty_h 1
@@ -119,9 +121,9 @@ public:
   }
 
   // Functions to compute reflection probabilities vs. frequency
-  G4double AnharmonicReflProb(G4double freq) const;
-  G4double DiffuseReflProb(G4double freq) const;
-  G4double SpecularReflProb(G4double freq) const;
+  G4double AnharmonicReflProb(G4double freq = -1.) const;
+  G4double DiffuseReflProb(G4double freq = -1.) const;
+  G4double SpecularReflProb(G4double freq = -1.) const;
 
   // Complex electrode geometries
   void SetChargeElectrode(G4CMPVElectrodePattern* cel);

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -181,12 +181,12 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
   G4ThreeVector reflDir;
 
   if (random < specProb) {
-    reflDir = DoSpecularReflection(aTrack, aStep);
+    reflP = DoSpecularReflection(aTrack, aStep);
   } else { // Do diffuse reflection (electrons & holes)
-    reflDir = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
+    reflP = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
   }
 
-  FillParticleChange(GetCurrentValley(), aTrack.GetKineticEnergy(), reflDir);
+  FillParticleChange(GetCurrentValley(), reflP);
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
@@ -194,20 +194,20 @@ DoSpecularReflection(const G4Track& aTrack, const G4Step& aStep) {
   if (verboseLevel>1)
     G4cout << GetProcessName() << ": Electron reflected" << G4endl;
 
-  G4ThreeVector reflDir;
+  G4ThreeVector reflP;
   
-  if (IsElectron())  reflDir = DoSpecRefElectron(aTrack, aStep);
-  else if (IsHole()) reflDir = DoSpecRefHole(aStep);
+  if (IsElectron())  reflP = DoSpecularElectron(aTrack, aStep);
+  else if (IsHole()) reflP = DoSpecularHole(aStep);
   else {
     G4Exception("G4CMPDriftBoundaryProcess::DoReflection", "Boundary004",
                 EventMustBeAborted, "Invalid particle for this process.");
   }
 
-  return reflDir;
+  return reflP;
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
-DoSpecRefElectron(const G4Track& aTrack, const G4Step& aStep) {
+DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
   G4ThreeVector k = GetLocalWaveVector(aTrack);
   G4ThreeVector surfNorm = G4CMP::GetSurfaceNormal(aStep);
 
@@ -223,6 +223,12 @@ DoSpecRefElectron(const G4Track& aTrack, const G4Step& aStep) {
   // Specular reflection reverses wavevector along normal
   G4double dirNorm = k * surfNorm;
   G4ThreeVector k -= 2.*dirNorm*surfNorm;
+
+  // If reflected velocity is outward facing, fall back to diffuse reflection
+  G4int mode = GetPolarization(aStep.GetTrack());
+  if (!G4CMP::VelocityIsInward(theLattice, mode, k, surfNorm)) {
+    k = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
+  }
   
   if (verboseLevel>2) {
     G4cout << " New wavevector direction " << k.unit() << G4endl;
@@ -243,11 +249,11 @@ DoSpecRefElectron(const G4Track& aTrack, const G4Step& aStep) {
     G4cout << " Cross-check new wavevector direction " << vnew.unit() << G4endl;
   }
 
-  return k;
+  return p;
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
-DoSpecRefHole(const G4Step& aStep) {
+DoSpecularHole(const G4Step& aStep) {
   if (verboseLevel>1) {
     G4cout << GetProcessName() << "DoSpecularHole " << G4endl;
   }
@@ -266,7 +272,7 @@ DoSpecRefHole(const G4Step& aStep) {
     G4cout << " New momentum direction " << momDir << G4endl;
   }
   
-  return momDir;
+  return aTrack.GetMomentum().mag() * momDir;
 }
 
 

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -228,7 +228,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
   // If reflected velocity is outward facing, fall back to diffuse reflection
   G4int mode = GetPolarization(aStep.GetTrack());
   if (!G4CMP::VelocityIsInward(theLattice, mode, k, surfNorm)) {
-    k = LambertianReflection(theLattice, surfNorm, GetCurrentValley());
+    return LambertianReflection(theLattice, surfNorm, GetCurrentValley());
   }
   
   if (verboseLevel>2) {

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -19,6 +19,7 @@
 // 20250927  AbsorbTrack() should use '&&' to require that both conditions pass
 // 20251204  G4CMP-511 -- Create parallel Lambertian reflection code for charges.
 // 20251210  G4CMP-518 -- Make PhononVelocityIsInward() generic.
+// 20250219  G4CMP-513 : Provide separate specular and diffuse reflection for charges.
 
 #include "G4CMPDriftBoundaryProcess.hh"
 #include "G4CMPConfigManager.hh"
@@ -167,69 +168,69 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
   if (verboseLevel>1)
     G4cout << GetProcessName() << ": Track reflected" << G4endl;
 
-  // Electrons and holes need to be handled separately until we further
-  // generalize the physics.
+  G4double specProb = surfProp->SpecularReflProb();
+  G4double diffuseProb = surfProp->DiffuseReflProb();
 
-  if (IsElectron())  DoReflectionElectron(aTrack, aStep, aParticleChange);
-  else if (IsHole()) DoReflectionHole(aTrack, aStep, aParticleChange);
-  else {
-    G4Exception("G4CMPDriftBoundaryProcess::DoReflection", "Boundary004",
-                EventMustBeAborted, "Invalid particle for this process.");
-  }
-}
+  G4double norm = specProb + diffuseProb;
 
-void G4CMPDriftBoundaryProcess::
-DoReflectionElectron(const G4Track& aTrack, const G4Step& aStep,
-		     G4ParticleChange& particleChange) {
-  if (verboseLevel>1)
-    G4cout << GetProcessName() << ": Electron reflected" << G4endl;
+  specProb /= norm;
+  diffuseProb /= norm;
 
-  // Get outward normal from current volume
-  G4ThreeVector surfNorm = G4CMP::GetSurfaceNormal(aStep);
-
-  // Check whether step has proper boundary-stopped geometry
-  G4ThreeVector surfacePoint;
-  if (!CheckStepBoundary(aStep, surfacePoint)) {
-    if (verboseLevel>2)
-      G4cout << " Boundary point moved to " << surfacePoint << G4endl;
-
-    particleChange.ProposePosition(surfacePoint);	// IS THIS CORRECT?!?
-  }
-
-  // FUTURE: Get specular vs. diffuse probability from parameters
-  G4bool specular = false;
+  G4double random = G4UniformRand();
 
   G4ThreeVector reflDir;
-  if (specular) {
-    G4ThreeVector vel = GetGlobalVelocityVector(aTrack);
-    reflDir = DoSpecularElectron(vel, surfNorm, surfacePoint);
-  } else {
-    reflDir = DoDiffuseElectron(surfNorm, surfacePoint);
+
+  if (random < specProb) {
+    reflDir = DoSpecularReflection(aTrack, aStep);
+  } else { // Do diffuse reflection (electrons & holes)
+    reflDir = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
   }
 
   FillParticleChange(GetCurrentValley(), aTrack.GetKineticEnergy(), reflDir);
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
-DoSpecularElectron(const G4ThreeVector& inDir,
-		   const G4ThreeVector& surfNorm,
-		   const G4ThreeVector& /*surfPos*/) const {
-  if (verboseLevel>2) G4cout << " DoSpecularElectron " << surfNorm << G4endl;
+DoSpecularReflection(const G4Track& aTrack, const G4Step& aStep) {
+  if (verboseLevel>1)
+    G4cout << GetProcessName() << ": Electron reflected" << G4endl;
 
-  if (verboseLevel>2) {
-    G4cout << " Old velocity direction " << inDir.unit() << G4endl;
+  G4ThreeVector reflDir;
+  
+  if (IsElectron())  reflDir = DoSpecRefElectron(aTrack, aStep);
+  else if (IsHole()) reflDir = DoSpecRefHole(aStep);
+  else {
+    G4Exception("G4CMPDriftBoundaryProcess::DoReflection", "Boundary004",
+                EventMustBeAborted, "Invalid particle for this process.");
   }
 
-  // Specular reflection reverses velocity along normal
-  G4double dirNorm = inDir * surfNorm;
-  G4ThreeVector outDir = inDir - 2.*dirNorm*surfNorm;
+  return reflDir;
+}
+
+G4ThreeVector G4CMPDriftBoundaryProcess::
+DoSpecRefElectron(const G4Track& aTrack, const G4Step& aStep) {
+  G4ThreeVector k = GetLocalWaveVector(aTrack);
+  G4ThreeVector surfNorm = G4CMP::GetSurfaceNormal(aStep);
+
+  if (verboseLevel>1) {
+    G4cout << " DoSpecularElectron " << G4endl;
+  }
+
+  if (verboseLevel>2) {
+    G4cout << " surfNorm " << surfNorm << G4endl;
+    G4cout << " Old wavevector direction " << k.unit() << G4endl;
+  }
+
+  // Specular reflection reverses wavevector along normal
+  G4double dirNorm = k * surfNorm;
+  G4ThreeVector k -= 2.*dirNorm*surfNorm;
   
-  if (verboseLevel>2)
-    G4cout << " New velocity direction " << outDir.unit() << G4endl;
+  if (verboseLevel>2) {
+    G4cout << " New wavevector direction " << k.unit() << G4endl;
+  }
   
-  // Convert velocity back to momentum and update direction
-  RotateToLocalDirection(outDir);
-  G4ThreeVector p = theLattice->MapV_elToP(GetCurrentValley(), outDir);
+  // Convert wavevector back to momentum and update direction
+  RotateToGlobalDirection(k);
+  G4ThreeVector p = theLattice->MapV_elToP(GetCurrentValley(), k);
   RotateToGlobalDirection(p);
   
   if (verboseLevel>2) {
@@ -239,44 +240,35 @@ DoSpecularElectron(const G4ThreeVector& inDir,
     G4ThreeVector vnew = theLattice->MapPtoV_el(GetCurrentValley(),
 						GetLocalDirection(p));
     RotateToGlobalDirection(vnew);
-    G4cout << " Cross-check new v dir  " << vnew.unit() << G4endl;
+    G4cout << " Cross-check new wavevector direction " << vnew.unit() << G4endl;
   }
 
-  return outDir;
+  return k;
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
-DoDiffuseElectron(const G4ThreeVector& surfNorm,
-		  const G4ThreeVector& /*surfPos*/) const {
-  if (verboseLevel>2) G4cout << " DoDiffuseElectron " << surfNorm << G4endl;
-
-  // Charge scatters randomly off of surface
-  G4ThreeVector p = GetLambertianVector(surfNorm);
-  return p;
-}
-
-
-void G4CMPDriftBoundaryProcess::
-DoReflectionHole(const G4Track& /*aTrack*/, const G4Step& aStep,
-		 G4ParticleChange& /*aParticleChange*/) {
-  if (verboseLevel>1)
-    G4cout << GetProcessName() << ": Hole reflected" << G4endl;
+DoSpecRefHole(const G4Step& aStep) {
+  if (verboseLevel>1) {
+    G4cout << GetProcessName() << "DoSpecularHole " << G4endl;
+  }
 
   G4ThreeVector surfNorm = G4CMP::GetSurfaceNormal(aStep);
 
-  // TODO: If we do the electrons Lambertian, we should do the holes also
   G4ThreeVector momDir = aStep.GetPostStepPoint()->GetMomentumDirection();
-  if (verboseLevel>2)
+  if (verboseLevel>2) {
     G4cout << " Old momentum direction " << momDir << G4endl;
+  }
   
   G4double momNorm = momDir * surfNorm;
   momDir -= 2.*momNorm*surfNorm;
   
-  if (verboseLevel>2)
+  if (verboseLevel>2) {
     G4cout << " New momentum direction " << momDir << G4endl;
+  }
   
-  aParticleChange.ProposeMomentumDirection(momDir);
+  return momDir;
 }
+
 
 // Called when maximum bounces have been recorded; does recombination
 

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -184,7 +184,7 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
     reflP = DoSpecularReflection(aTrack, aStep);
   } else { // Do diffuse reflection (electrons & holes)
     reflP = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
-    reflP *= GetGlobalMomentum().mag();
+    reflP *= GetGlobalMomentum(aTrack).mag();
   }
 
   FillParticleChange(GetCurrentValley(), reflP);

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -178,7 +178,7 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
 
   G4double random = G4UniformRand();
 
-  G4ThreeVector reflDir;
+  G4ThreeVector reflP;
 
   if (random < specProb) {
     reflP = DoSpecularReflection(aTrack, aStep);
@@ -253,7 +253,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
-DoSpecularHole(const G4Step& aStep) {
+DoSpecularHole(const G4Track& /*aTrack*/, const G4Step& aStep) {
   if (verboseLevel>1) {
     G4cout << GetProcessName() << "DoSpecularHole " << G4endl;
   }

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -197,7 +197,7 @@ DoSpecularReflection(const G4Track& aTrack, const G4Step& aStep) {
   G4ThreeVector reflP;
   
   if (IsElectron())  reflP = DoSpecularElectron(aTrack, aStep);
-  else if (IsHole()) reflP = DoSpecularHole(aStep);
+  else if (IsHole()) reflP = DoSpecularHole(aTrack, aStep);
   else {
     G4Exception("G4CMPDriftBoundaryProcess::DoReflection", "Boundary004",
                 EventMustBeAborted, "Invalid particle for this process.");
@@ -253,7 +253,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
 }
 
 G4ThreeVector G4CMPDriftBoundaryProcess::
-DoSpecularHole(const G4Track& /*aTrack*/, const G4Step& aStep) {
+DoSpecularHole(const G4Track& aTrack, const G4Step& aStep) {
   if (verboseLevel>1) {
     G4cout << GetProcessName() << "DoSpecularHole " << G4endl;
   }

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -227,7 +227,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
   // If reflected velocity is outward facing, fall back to diffuse reflection
   G4int mode = GetPolarization(aStep.GetTrack());
   if (!G4CMP::VelocityIsInward(theLattice, mode, k, surfNorm)) {
-    k = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
+    k = LambertianReflection(theLattice, surfNorm, GetCurrentValley());
   }
   
   if (verboseLevel>2) {
@@ -235,7 +235,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
   }
   
   // Convert wavevector back to momentum and update direction
-  RotateToGlobalDirection(k);
+  RotateToLocalDirection(k);
   G4ThreeVector p = theLattice->MapV_elToP(GetCurrentValley(), k);
   RotateToGlobalDirection(p);
   
@@ -243,10 +243,10 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
     G4cout << " New momentum direction " << p.unit() << G4endl;
     
     // SANITY CHECK:  Does new momentum get back to new velocity?
-    G4ThreeVector vnew = theLattice->MapPtoV_el(GetCurrentValley(),
+    G4ThreeVector kNew = theLattice->MapPtoK(GetCurrentValley(),
 						GetLocalDirection(p));
-    RotateToGlobalDirection(vnew);
-    G4cout << " Cross-check new wavevector direction " << vnew.unit() << G4endl;
+    RotateToGlobalDirection(kNew);
+    G4cout << " Cross-check new wavevector direction " << kNew.unit() << G4endl;
   }
 
   return p;

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -222,7 +222,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
 
   // Specular reflection reverses wavevector along normal
   G4double dirNorm = k * surfNorm;
-  G4ThreeVector k -= 2.*dirNorm*surfNorm;
+  k -= 2.*dirNorm*surfNorm;
 
   // If reflected velocity is outward facing, fall back to diffuse reflection
   G4int mode = GetPolarization(aStep.GetTrack());

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -209,6 +209,7 @@ DoSpecularReflection(const G4Track& aTrack, const G4Step& aStep) {
 G4ThreeVector G4CMPDriftBoundaryProcess::
 DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
   G4ThreeVector k = GetLocalWaveVector(aTrack);
+  RotateToGlobalDirection(k);
   G4ThreeVector surfNorm = G4CMP::GetSurfaceNormal(aStep);
 
   if (verboseLevel>1) {
@@ -235,8 +236,7 @@ DoSpecularElectron(const G4Track& aTrack, const G4Step& aStep) {
   }
   
   // Convert wavevector back to momentum and update direction
-  RotateToLocalDirection(k);
-  G4ThreeVector p = theLattice->MapV_elToP(GetCurrentValley(), k);
+  G4ThreeVector p = theLattice->MapV_elToP(GetCurrentValley(), GetLocalDirection(k));
   RotateToGlobalDirection(p);
   
   if (verboseLevel>2) {

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -184,6 +184,7 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
     reflP = DoSpecularReflection(aTrack, aStep);
   } else { // Do diffuse reflection (electrons & holes)
     reflP = LambertianReflection(theLattice, G4CMP::GetSurfaceNormal(aStep), GetCurrentValley());
+    reflP *= GetGlobalMomentum().mag();
   }
 
   FillParticleChange(GetCurrentValley(), reflP);

--- a/library/src/G4CMPSurfaceProperty.cc
+++ b/library/src/G4CMPSurfaceProperty.cc
@@ -14,6 +14,8 @@
 // 20220824  R. Cormier -- Default to scalar probs if no polynomials
 // 20230429  G4CMP-357: Move mutex in GetXyzElectrode() to avoid data race.
 // 20260105  G4CMP-514: Modify G4CMPSurfaceProperty for specular reflection.
+// 20260205  G4CMP-582: Make the frequency parameter of RefProb functions
+//    in G4CMPSurfaceProperty optional.
 
 #include "G4CMPSurfaceProperty.hh"
 #include "G4CMPVElectrodePattern.hh"
@@ -216,13 +218,13 @@ ExpandCoeffsPoly(G4double freq, const std::vector<G4double>& coeff) const {
 }
 
 G4double G4CMPSurfaceProperty::AnharmonicReflProb(G4double freq) const {
-  if (anharmonicCoeffs.empty() || freq > anharmonicMaxFreq) return 0.;
+  if (freq < 0 || anharmonicCoeffs.empty() || freq > anharmonicMaxFreq) return 0.;
  
   return ExpandCoeffsPoly(freq, anharmonicCoeffs);
 }
 
 G4double G4CMPSurfaceProperty::DiffuseReflProb(G4double freq) const {
-  if (diffuseCoeffs.empty() || freq > anharmonicMaxFreq)
+  if (freq < 0 || diffuseCoeffs.empty() || freq > anharmonicMaxFreq)
     return 1. - thePhononMatPropTable.GetConstProperty("specProb");
 
   if (freq > diffuseMaxFreq) freq = diffuseMaxFreq;	// Flat plateau
@@ -230,7 +232,7 @@ G4double G4CMPSurfaceProperty::DiffuseReflProb(G4double freq) const {
 }
 
 G4double G4CMPSurfaceProperty::SpecularReflProb(G4double freq) const {
-  if (specularCoeffs.empty() || freq > diffuseMaxFreq)
+  if (freq < 0 || specularCoeffs.empty() || freq > diffuseMaxFreq)
     return 1. - DiffuseReflProb(freq) - AnharmonicReflProb(freq);
 
   return ExpandCoeffsPoly(freq, specularCoeffs);


### PR DESCRIPTION
Split DriftBoundaryProcess::DoElectronReflection() and DoHoleReflection() into separate specular and diffuse functions. May be possible to have simple top-level DoReflection() function which handles the specular/diffuse split, and a similar unified diffuse reflection function (just throw outgoing transport momentum direction).

Specular reflection needs to be different for electrons, because of the mass tensor. We reflect the wavevector, convert back to transport momentum, and fall back to diffuse scattering if the resulting momentum is not inward. This will be a modification of the specular electron reflection code currently on branch [G4CMP-503](https://jira.slac.stanford.edu/browse/G4CMP-503), which uses velocity instead of wavevector.