### PR TITLE
Replaced Fatal Exception blocks triggered by diffusion edge cases wit…

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-03-25  G4CMP-592 : Replace FatalExceptions in QPDiffusion with warnings
+
 2026-02-24  g4cmp-V10-01-01 Multiple bug fixes for G4v11 and new TFR/QP code
 2026-02-20  G4CMP-585 : Fix memory leak from G4CMP-547 ParticleChange mod.
 2026-02-18  G4CMP-588 : Must present NumberOfSecondaries before filling.

--- a/library/include/G4CMPQPDiffusion.hh
+++ b/library/include/G4CMPQPDiffusion.hh
@@ -124,6 +124,9 @@ private:
   G4double SampleTimeStepFromFirstPassageDistribution(G4double the2DSafety);
   G4double SampleDimensionlessTimeStepUsingAcceptanceRejectionTechnique();
   
+  G4CMPParticleChangeForQPDiffusion* DoSimpleQPKill();
+  G4ThreeVector PrepSimpleQPKillWithNullReturnVect();
+  
 protected:
   virtual G4bool UpdateMeanFreePathForLatticeChangeover(const G4Track& aTrack);
   virtual void UpdateSCAfterLatticeChange();

--- a/library/src/G4CMPGeometryUtils.cc
+++ b/library/src/G4CMPGeometryUtils.cc
@@ -377,9 +377,11 @@ G4CMP::Compute2DSafetyToDaughterVolume(const G4ThreeVector& pos,
   if (volDaughterSolid->Inside(samplePoint) == kInside) {
     G4ExceptionDescription msg;
     msg << "G4CMP::Compute2DSafetyToDaughterVolume seems to think we're "
-        << "already inside the daughter volume." << G4endl;
+        << "already inside the daughter volume. Returning negative safety "
+        << " to kill track." << G4endl;
     G4Exception("G4CMP::Compute2DSafetyToDaughterVolume()", "Geometry00X",
-                FatalException, msg);
+                JustWarning, msg);
+    return -1.0*CLHEP::um;
   }
   
   //Compute the safety. Since we should be *outside* the daughter volume
@@ -552,9 +554,12 @@ Compute2DSafetyInMotherVolume(G4VSolid * motherSolid,
     G4ExceptionDescription msg;
     msg << "G4CMP::Compute2DSafetyInMotherVolume has a returnDir whose "
         << "magnitude is zero. Given that this is swept, this should not be "
-        << "the case." << G4endl;
+        << "the case. Throwing negative safety so track gets killed" << G4endl;
     G4Exception("G4CMP::Compute2DSafetyInMotherVolume()", "Geometry00X",
-                FatalException, msg);    
+                JustWarning, msg);
+
+    //Set the safety negative, so we can pick it up with our kill-the-track flag
+    motherSafety = -1.0*CLHEP::um;
   }
   
   return motherSafety;

--- a/library/src/G4CMPGeometryUtils.cc
+++ b/library/src/G4CMPGeometryUtils.cc
@@ -167,7 +167,7 @@ G4CMP::Get2DSafetyWithDirection(const G4VTouchable* motherTouch,
     G4ExceptionDescription msg;
     msg << "G4CMP::Get2DSafetyWithDirection is returning a null direction. "
         << "Something is not running correctly.";
-    G4Exception("G4CMP::Get2DSafetyWithDirection()", "Geometry00X",
+    G4Exception("G4CMP::Get2DSafetyWithDirection()", "Geometry001",
                 FatalException, msg);
   }
 
@@ -379,9 +379,9 @@ G4CMP::Compute2DSafetyToDaughterVolume(const G4ThreeVector& pos,
     msg << "G4CMP::Compute2DSafetyToDaughterVolume seems to think we're "
         << "already inside the daughter volume. Returning negative safety "
         << " to kill track." << G4endl;
-    G4Exception("G4CMP::Compute2DSafetyToDaughterVolume()", "Geometry00X",
+    G4Exception("G4CMP::Compute2DSafetyToDaughterVolume()", "Geometry002",
                 JustWarning, msg);
-    return -1.0*CLHEP::um;
+    return -1.0*um;
   }
   
   //Compute the safety. Since we should be *outside* the daughter volume
@@ -450,7 +450,7 @@ G4CMP::Compute2DSafetyToDaughterVolume(const G4ThreeVector& pos,
             << "volDaughter safety is not zero when the current boundary "
             << "belongs to this daughter. This is contrary to what should "
             << "happen." << G4endl;
-        G4Exception("G4CMP::Compute2DSafetyToDaughterVolume()", "Geometry00X",
+        G4Exception("G4CMP::Compute2DSafetyToDaughterVolume()", "Geometry003",
                     FatalException, msg);
       }
       returnDir = G4ThreeVector(0,0,0);
@@ -525,7 +525,7 @@ Compute2DSafetyInMotherVolume(G4VSolid * motherSolid,
     G4ExceptionDescription msg;
     msg << "G4CMP::Compute2DSafetyInMotherVolume seems to think we're outside "
         << "the mother volume." << G4endl;
-    G4Exception("G4CMP::Compute2DSafetyInMotherVolume()", "Geometry00X",
+    G4Exception("G4CMP::Compute2DSafetyInMotherVolume()", "Geometry004",
                 FatalException, msg);
   }
   
@@ -555,11 +555,11 @@ Compute2DSafetyInMotherVolume(G4VSolid * motherSolid,
     msg << "G4CMP::Compute2DSafetyInMotherVolume has a returnDir whose "
         << "magnitude is zero. Given that this is swept, this should not be "
         << "the case. Throwing negative safety so track gets killed" << G4endl;
-    G4Exception("G4CMP::Compute2DSafetyInMotherVolume()", "Geometry00X",
+    G4Exception("G4CMP::Compute2DSafetyInMotherVolume()", "Geometry005",
                 JustWarning, msg);
 
     //Set the safety negative, so we can pick it up with our kill-the-track flag
-    motherSafety = -1.0*CLHEP::um;
+    motherSafety = -1.0*um;
   }
   
   return motherSafety;
@@ -979,7 +979,7 @@ G4ThreeVector G4CMP::GetSurfaceNormal(const G4Step& step, const G4ThreeVector& i
     msg << "G4CMP::GetSurfaceNormal() seems to think we're not on a surface. "
         << "Volumes are: "
         << preSolid->GetName() << " and " << postSolid->GetName() << G4endl;
-    G4Exception("G4CMP::GetSurfaceNormal()", "Geometry00X",
+    G4Exception("G4CMP::GetSurfaceNormal()", "Geometry006",
                 FatalException, msg);
     G4ThreeVector dummy(0,0,0);
     output = dummy;
@@ -1101,7 +1101,7 @@ G4double G4CMP::ComputeDotProductThreshold_Norm(int full_circle_nV) {
     G4ExceptionDescription msg;
     msg << "G4CMP::ComputeDotProductThreshold_Norm seems to see that "
         << "half_circle_nV is not divisible by two. Please fix." << G4endl;
-    G4Exception("G4CMP::ComputeDotProductThreshold_Norm()", "Geometry00X",
+    G4Exception("G4CMP::ComputeDotProductThreshold_Norm()", "Geometry009",
                 FatalException, msg);
   }
     
@@ -1123,7 +1123,7 @@ G4double G4CMP::ComputeDotProductThreshold_Tang(int full_circle_nV) {
     G4ExceptionDescription msg;
     msg << "G4CMP::ComputeDotProductThreshold_Tang seems to see that "
         << "half_circle_nV is not divisible by two. Please fix." << G4endl;
-    G4Exception("G4CMP::ComputeDotProductThreshold_Tang()", "Geometry00X",
+    G4Exception("G4CMP::ComputeDotProductThreshold_Tang()", "Geometry010",
                 FatalException, msg);
   }
   

--- a/library/src/G4CMPQPDiffusion.cc
+++ b/library/src/G4CMPQPDiffusion.cc
@@ -71,8 +71,8 @@ G4CMPQPDiffusion::G4CMPQPDiffusion(const G4String& name,
   fPreDiffusionPathLength = 0.0;
   fDiffConst =  0.0;
   fBoundaryFudgeFactor = 1.001;
-  fSoftFloorBoundaryScale = 100*CLHEP::nm;
-  fHardFloorBoundaryScale = 10*CLHEP::nm;
+  fSoftFloorBoundaryScale = 10*CLHEP::nm;//100*CLHEP::nm;
+  fHardFloorBoundaryScale = 1*CLHEP::nm;//10*CLHEP::nm;
   fPicometerScale = 0.001*CLHEP::nm;
   
   //fSafetyHelper is initialized in AlongStepGPIL
@@ -796,9 +796,14 @@ G4VParticleChange* G4CMPQPDiffusion::AlongStepDoIt(const G4Track& track,
               << " All tries exhausted, which suggests this is perhaps a more "
               << "fundamental issue with G4CMP, or maybe your geometry is just "
               << "not following the recommended rules for tracked film "
-              << "response.";
+              << "response. Killing Track.";
           G4Exception("G4CMPQPDiffusion::AlongStepDoIt", "QPDiffusion006",
-                      FatalException, amg);
+                      JustWarning, amg);
+
+          //Rather than killing the whole program, kill the track
+          fPreemptivelyKillTrack = true;
+          fParticleChange.ProposeTrackStatus(fStopAndKill);
+          return &fParticleChange;
         }		
       } else {
 
@@ -965,6 +970,13 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                        trackPosition,
                        track.GetMomentumDirection(),
                        false);
+
+  //Cross-check for deliberately negative safeties -- need to kill these tracks)
+  if( the2DSafety < 0.0 ){
+    fPreemptivelyKillTrack = true;
+    fParticleChange.ProposeTrackStatus(fStopAndKill);
+    return &fParticleChange;
+  }
   
   //Debugging
   if (verboseLevel > 5) {
@@ -1009,9 +1021,14 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
         G4ExceptionDescription msg;
         msg << "When nudging position to be farther from the boundary than "
             << "the hardFloorBoundaryScale, exceeded max attempts (1000)."
-            << G4endl;
+            << "Killing track." << G4endl;
         G4Exception("G4CMPQPDiffusion::PostStepDoIt", "QPDiffusion009",
-                    FatalException, msg);
+                    JustWarning, msg);
+
+        //Kill the track.
+        fPreemptivelyKillTrack = true;
+        fParticleChange.ProposeTrackStatus(fStopAndKill);
+        return &fParticleChange;
       }
             
       G4ThreeVector nudgeDir = G4RandomDirection();
@@ -1046,6 +1063,13 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                            nudgedPosition,
                            track.GetMomentumDirection(),
                            false);
+
+      //Cross-check for deliberately negative safeties -- need to kill these tracks)
+      if( testSafety < 0.0 ){
+        fPreemptivelyKillTrack = true;
+        fParticleChange.ProposeTrackStatus(fStopAndKill);
+        return &fParticleChange;
+      }
       if (testSafety < fHardFloorBoundaryScale) continue;
 
       //Debugging
@@ -1129,12 +1153,26 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
       the2DSafety = the2DSafetyAndDir.first;
       G4ThreeVector safetyDir = the2DSafetyAndDir.second;
 
+      //Cross-check for deliberately negative safeties -- need to kill these tracks
+      if( the2DSafety < 0.0 ){
+        fPreemptivelyKillTrack = true;
+        fParticleChange.ProposeTrackStatus(fStopAndKill);
+        return &fParticleChange;
+      }
+
       //Do a second check, moving along the direction of the safety
       G4ThreeVector shiftedPosForTest = trackPosition+safetyDir*the2DSafety*0.5;
       std::pair<G4double,G4ThreeVector> the2DSafetyAndDir_Shifted =
         G4CMP::Get2DSafetyWithDirection(track.GetStep()->GetPreStepPoint()->GetTouchable(),
                                         shiftedPosForTest,
                                         track.GetMomentumDirection(),false);
+
+      //Cross-check for deliberately negative safeties -- need to kill these tracks
+      if( the2DSafetyAndDir_Shifted.first < 0.0 ){
+        fPreemptivelyKillTrack = true;
+        fParticleChange.ProposeTrackStatus(fStopAndKill);
+        return &fParticleChange;
+      }
 
       //Another sanity check -- if we've repeated and STILL fail to pick a
       //direction that gives an expected change in the safety when we
@@ -1298,7 +1336,14 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        track.GetMomentumDirection(),
                        false,
                        useSweepForDaughterSafety);
-  
+
+  //Cross-check for deliberately negative safeties -- need to kill these tracks
+  if( shiftedPoint2DSafety < 0.0 ){
+    fPreemptivelyKillTrack = true;
+    G4ThreeVector theDummyVect(0,0,0);
+    return theDummyVect;
+  }
+
   //Debugging
   if (verboseLevel > 5) {
     G4cout << "FDTNB Function Point A | pos: " << trackPosition
@@ -1407,6 +1452,13 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        false,
                        useSweepForDaughterSafety);
 
+  //Cross-check for deliberately negative safeties -- need to kill these tracks
+  if( option1Safety < 0.0 ){
+    fPreemptivelyKillTrack = true;
+    G4ThreeVector theDummyVect(0,0,0);
+    return theDummyVect;
+  }
+
   //Debugging
   if (verboseLevel > 5) {
     G4cout << "FDTNB Function Point DA | option 1 safety: " << option1Safety
@@ -1419,7 +1471,14 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        track.GetMomentumDirection(),
                        false,
                        useSweepForDaughterSafety);
-  
+
+  //Cross-check for deliberately negative safeties -- need to kill these tracks
+  if( option2Safety < 0.0 ){
+    fPreemptivelyKillTrack = true;
+    G4ThreeVector theDummyVect(0,0,0);
+    return theDummyVect;
+  }
+
   //Debugging
   if (verboseLevel > 5) {
     G4cout << "FDTNB Function Point DB | option 2 safety: "
@@ -1469,9 +1528,15 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                          track.GetMomentumDirection(),
                          false,
                          useSweepForDaughterSafety);
+
+    //Cross-check for deliberately negative safeties -- need to kill these tracks
+    if( option1Safety < 0.0 || option2Safety < 0.0 ){
+      fPreemptivelyKillTrack = true;
+      G4ThreeVector theDummyVect(0,0,0);
+      return theDummyVect;
+    }
   }
 
-  
   //If option 1 safety is lower, it means we return option 1 as the direction
   //to the boundary
   G4ThreeVector outputDir;
@@ -1527,6 +1592,13 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        track.GetMomentumDirection(), 
                        false,
                        useSweepForDaughterSafety);
+
+  //Cross-check for deliberately negative safeties -- need to kill these tracks
+  if( checkedSafety < 0.0 ){
+    fPreemptivelyKillTrack = true;
+    G4ThreeVector theDummyVect(0,0,0);
+    return theDummyVect;
+  }
   
   if (fabs((checkedSafety/the2DSafety) - 0.5) >
       fractionalSafetyDifferenceThreshold) {
@@ -1827,6 +1899,8 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
   //and that it is the same as the lattice corresponding to what the
   //latticeManager sees as belonging to currentVolPlusEps. This is purely a
   //check.
+  //Since I now see this gets triggered a part in a million tracks, for now
+  //just making this a warning and killing the track
   if (theStatus == fGeomBoundary && !LM->HasLattice(currentVolPlusEps)) {
     G4ExceptionDescription msg;
     msg << "We're on a boundary (i.e. our boundary is now behind us) and find "
@@ -1836,9 +1910,12 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
         << momentumDir << ", trackPosition_eps = " << trackPosition_eps
         << ", trackPosition_mineps: " << trackPosition_mineps
         << ", currenVolPlusEps: " << currentVolPlusEps->GetName()
-        << ", currentVolMinEps: " << currentVolMinEps->GetName();
+        << ", currentVolMinEps: " << currentVolMinEps->GetName()
+        << ". Killing Track." << G4endl;
     G4Exception("G4CMPQPDiffusion::GetMeanFreePath", "QPDiffusion016",
-                FatalException, msg);
+                JustWarning, msg);
+    fPreemptivelyKillTrack = true;
+    return 0;
   }
 
   //Compute a step length corresponding to the nearest surface in 2D
@@ -1884,6 +1961,12 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                                true,
                                false,
                                surfaceNorm );
+
+          //Cross-check for deliberately negative safeties -- need to kill these tracks
+          if( the2DSafety < 0.0 ) {
+            fPreemptivelyKillTrack = true;
+            return 0;
+          }
         } else {	 
           std::pair<G4double,G4ThreeVector> the2DSafetyAndDir =
             G4CMP::Get2DSafetyWithDirection(track.GetStep()->GetPreStepPoint()->GetTouchable(),
@@ -1892,7 +1975,13 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                                             true,
                                             surfaceNorm);
           the2DSafety = the2DSafetyAndDir.first;
-	  
+
+          //Cross-check for deliberately negative safeties -- need to kill these tracks
+          if( the2DSafety < 0.0 ) {
+            fPreemptivelyKillTrack = true;
+            return 0;
+          }
+
           G4ExceptionDescription msg;
           msg << "In GetMFP We're somehow on a boundary and also have triggered"
               << " the fNeedSweptSafetyInGetMFP. What is happening? (In "
@@ -1929,7 +2018,6 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
           return 0;
         }
 
-
         //Debugging
         if (verboseLevel > 5) {
           G4cout << "GMFP Function Point EB | QP Is stuck!" << G4endl;
@@ -1959,6 +2047,12 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                              outgoingSurfaceTangents.first,
                              outgoingSurfaceTangents.second);	
         the2DSafety = constrained2DSafety;
+
+        //Cross-check for deliberately negative safeties -- need to kill these tracks
+        if( the2DSafety < 0.0 ) {
+          fPreemptivelyKillTrack = true;
+          return 0;
+        }
 
         //Debugging
         if (verboseLevel > 5) {
@@ -2009,6 +2103,12 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                              track.GetPosition(),
                              track.GetMomentumDirection(),
                              false);
+
+        //Cross-check for deliberately negative safeties -- need to kill these tracks
+        if( the2DSafety < 0.0 ) {
+          fPreemptivelyKillTrack = true;
+          return 0;
+        }
       } else {
         //^If we need the swept safety to compensate for G4 handling a daughter
         //safety wrong, then run the swept safety.
@@ -2019,9 +2119,22 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                                           track.GetMomentumDirection(),
                                           true);
         the2DSafety = the2DSafetyAndDir.first;
+
+        //Cross-check for deliberately negative safeties -- need to kill these tracks
+        if( the2DSafety < 0.0 ) {
+          fPreemptivelyKillTrack = true;
+          return 0;
+        }
       }
     }   
     f2DSafety = the2DSafety;
+
+    //Cross-check for deliberately negative safeties -- need to kill these tracks
+    //This is a bit of a safeguard one -- probably not necessary
+    if( the2DSafety < 0.0 ) {
+      fPreemptivelyKillTrack = true;
+      return 0;
+    }
 
     //Calculate the energy dependent diffusion constant
     G4double E_ratio = fGapEnergy/energy;

--- a/library/src/G4CMPQPDiffusion.cc
+++ b/library/src/G4CMPQPDiffusion.cc
@@ -452,11 +452,7 @@ G4VParticleChange* G4CMPQPDiffusion::AlongStepDoIt(const G4Track& track,
 
   //Kill event if we have a bad outgoing surface tangent -- think this should
   //actually go up after calling the outgoingsurfacetangent finding
-  if (fPreemptivelyKillTrack) {
-    fParticleChange.ProposeTrackStatus(fStopAndKill);
-    return &fParticleChange;
-  }
-
+  if (fPreemptivelyKillTrack) return DoSimpleQPKill();
   
   //Get the initial and final times -- since Transport runs first in the
   //alongStepDoIt processes, we should have the "transport-limited" times
@@ -801,9 +797,7 @@ G4VParticleChange* G4CMPQPDiffusion::AlongStepDoIt(const G4Track& track,
                       JustWarning, amg);
 
           //Rather than killing the whole program, kill the track
-          fPreemptivelyKillTrack = true;
-          fParticleChange.ProposeTrackStatus(fStopAndKill);
-          return &fParticleChange;
+          return DoSimpleQPKill();
         }		
       } else {
 
@@ -920,10 +914,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
 
   //Kill event if we have a bad outgoing surface tangent -- think this should
   //actually go up after calling the outgoingsurfacetangent finding
-  if (fPreemptivelyKillTrack) {
-    fParticleChange.ProposeTrackStatus(fStopAndKill);
-    return &fParticleChange;
-  }
+  if (fPreemptivelyKillTrack) return DoSimpleQPKill();
   
   //Determine if we're on a boundary. A few scenarios:
   //1. This shouldn't run if we are landing on a boundary in the step (where
@@ -972,11 +963,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                        false);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks)
-  if (the2DSafety < 0.0) {
-    fPreemptivelyKillTrack = true;
-    fParticleChange.ProposeTrackStatus(fStopAndKill);
-    return &fParticleChange;
-  }
+  if (the2DSafety < 0.0) return DoSimpleQPKill();
   
   //Debugging
   if (verboseLevel > 5) {
@@ -1026,9 +1013,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                     JustWarning, msg);
 
         //Kill the track.
-        fPreemptivelyKillTrack = true;
-        fParticleChange.ProposeTrackStatus(fStopAndKill);
-        return &fParticleChange;
+        return DoSimpleQPKill();
       }
             
       G4ThreeVector nudgeDir = G4RandomDirection();
@@ -1065,11 +1050,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                            false);
 
       //Cross-check for deliberately negative safeties -- need to kill these tracks)
-      if (testSafety < 0.0) {
-        fPreemptivelyKillTrack = true;
-        fParticleChange.ProposeTrackStatus(fStopAndKill);
-        return &fParticleChange;
-      }
+      if (testSafety < 0.0) return DoSimpleQPKill();
       if (testSafety < fHardFloorBoundaryScale) continue;
 
       //Debugging
@@ -1154,11 +1135,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
       G4ThreeVector safetyDir = the2DSafetyAndDir.second;
 
       //Cross-check for deliberately negative safeties -- need to kill these tracks
-      if (the2DSafety < 0.0) {
-        fPreemptivelyKillTrack = true;
-        fParticleChange.ProposeTrackStatus(fStopAndKill);
-        return &fParticleChange;
-      }
+      if (the2DSafety < 0.0) return DoSimpleQPKill();        
 
       //Do a second check, moving along the direction of the safety
       G4ThreeVector shiftedPosForTest = trackPosition+safetyDir*the2DSafety*0.5;
@@ -1168,11 +1145,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                                         track.GetMomentumDirection(),false);
 
       //Cross-check for deliberately negative safeties -- need to kill these tracks
-      if (the2DSafetyAndDir_Shifted.first < 0.0) {
-        fPreemptivelyKillTrack = true;
-        fParticleChange.ProposeTrackStatus(fStopAndKill);
-        return &fParticleChange;
-      }
+      if (the2DSafetyAndDir_Shifted.first < 0.0) return DoSimpleQPKill();
 
       //Another sanity check -- if we've repeated and STILL fail to pick a
       //direction that gives an expected change in the safety when we
@@ -1338,11 +1311,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if (shiftedPoint2DSafety < 0.0) {
-    fPreemptivelyKillTrack = true;
-    G4ThreeVector theDummyVect(0,0,0);
-    return theDummyVect;
-  }
+  if (shiftedPoint2DSafety < 0.0) return PrepSimpleQPKillWithNullReturnVect();
 
   //Debugging
   if (verboseLevel > 5) {
@@ -1453,11 +1422,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if (option1Safety < 0.0) {
-    fPreemptivelyKillTrack = true;
-    G4ThreeVector theDummyVect(0,0,0);
-    return theDummyVect;
-  }
+  if (option1Safety < 0.0) return PrepSimpleQPKillWithNullReturnVect();
 
   //Debugging
   if (verboseLevel > 5) {
@@ -1473,11 +1438,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if (option2Safety < 0.0) {
-    fPreemptivelyKillTrack = true;
-    G4ThreeVector theDummyVect(0,0,0);
-    return theDummyVect;
-  }
+  if (option2Safety < 0.0) return PrepSimpleQPKillWithNullReturnVect();
 
   //Debugging
   if (verboseLevel > 5) {
@@ -1531,9 +1492,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
 
     //Cross-check for deliberately negative safeties -- need to kill these tracks
     if (option1Safety < 0.0 || option2Safety < 0.0) {
-      fPreemptivelyKillTrack = true;
-      G4ThreeVector theDummyVect(0,0,0);
-      return theDummyVect;
+      return PrepSimpleQPKillWithNullReturnVect();
     }
   }
 
@@ -1594,11 +1553,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if (checkedSafety < 0.0) {
-    fPreemptivelyKillTrack = true;
-    G4ThreeVector theDummyVect(0,0,0);
-    return theDummyVect;
-  }
+  if (checkedSafety < 0.0) return PrepSimpleQPKillWithNullReturnVect();
   
   if (fabs((checkedSafety/the2DSafety) - 0.5) >
       fractionalSafetyDifferenceThreshold) {
@@ -2925,4 +2880,17 @@ FindSurfaceTangentsForStuckQPEjection(G4ThreeVector norm1,
   return output;
 }
 
+//Function for killing just a track, rather than the whole function, if
+//certain conditions are met
+G4CMPParticleChangeForQPDiffusion* G4CMPQPDiffusion::DoSimpleQPKill() {
+  fPreemptivelyKillTrack = true;
+  fParticleChange.ProposeTrackStatus(fStopAndKill);
+  return &fParticleChange;
+}
 
+//Function for prepping a track kill if certain conditions are met.
+G4ThreeVector G4CMPQPDiffusion::PrepSimpleQPKillWithNullReturnVect() {
+  fPreemptivelyKillTrack = true;
+  G4ThreeVector theDummyVect(0,0,0);
+  return theDummyVect;
+}

--- a/library/src/G4CMPQPDiffusion.cc
+++ b/library/src/G4CMPQPDiffusion.cc
@@ -745,7 +745,7 @@ G4VParticleChange* G4CMPQPDiffusion::AlongStepDoIt(const G4Track& track,
       //Whenever this is required, this will incur a small bias because we're
       //not changing the time duration for the step
       if (step.GetPostStepPoint()->GetStepStatus() != fGeomBoundary) {
-        if (verboseLevel > 5){
+        if (verboseLevel > 5) {
           G4ExceptionDescription msg;
           msg << "Somehow the CheckNextStep returned a step length that is not "
               << "kInfinity but the step status thinks it's not fGeomBoundary. "
@@ -972,7 +972,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                        false);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks)
-  if( the2DSafety < 0.0 ){
+  if (the2DSafety < 0.0) {
     fPreemptivelyKillTrack = true;
     fParticleChange.ProposeTrackStatus(fStopAndKill);
     return &fParticleChange;
@@ -1065,7 +1065,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                            false);
 
       //Cross-check for deliberately negative safeties -- need to kill these tracks)
-      if( testSafety < 0.0 ){
+      if (testSafety < 0.0) {
         fPreemptivelyKillTrack = true;
         fParticleChange.ProposeTrackStatus(fStopAndKill);
         return &fParticleChange;
@@ -1154,7 +1154,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
       G4ThreeVector safetyDir = the2DSafetyAndDir.second;
 
       //Cross-check for deliberately negative safeties -- need to kill these tracks
-      if( the2DSafety < 0.0 ){
+      if (the2DSafety < 0.0) {
         fPreemptivelyKillTrack = true;
         fParticleChange.ProposeTrackStatus(fStopAndKill);
         return &fParticleChange;
@@ -1168,7 +1168,7 @@ G4CMPQPDiffusion::PostStepDoIt(const G4Track& track, const G4Step&) {
                                         track.GetMomentumDirection(),false);
 
       //Cross-check for deliberately negative safeties -- need to kill these tracks
-      if( the2DSafetyAndDir_Shifted.first < 0.0 ){
+      if (the2DSafetyAndDir_Shifted.first < 0.0) {
         fPreemptivelyKillTrack = true;
         fParticleChange.ProposeTrackStatus(fStopAndKill);
         return &fParticleChange;
@@ -1338,7 +1338,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if( shiftedPoint2DSafety < 0.0 ){
+  if (shiftedPoint2DSafety < 0.0) {
     fPreemptivelyKillTrack = true;
     G4ThreeVector theDummyVect(0,0,0);
     return theDummyVect;
@@ -1453,7 +1453,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if( option1Safety < 0.0 ){
+  if (option1Safety < 0.0) {
     fPreemptivelyKillTrack = true;
     G4ThreeVector theDummyVect(0,0,0);
     return theDummyVect;
@@ -1473,7 +1473,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if( option2Safety < 0.0 ){
+  if (option2Safety < 0.0) {
     fPreemptivelyKillTrack = true;
     G4ThreeVector theDummyVect(0,0,0);
     return theDummyVect;
@@ -1530,7 +1530,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                          useSweepForDaughterSafety);
 
     //Cross-check for deliberately negative safeties -- need to kill these tracks
-    if( option1Safety < 0.0 || option2Safety < 0.0 ){
+    if (option1Safety < 0.0 || option2Safety < 0.0) {
       fPreemptivelyKillTrack = true;
       G4ThreeVector theDummyVect(0,0,0);
       return theDummyVect;
@@ -1594,7 +1594,7 @@ FindDirectionToNearbyBoundary(const G4Track& track,
                        useSweepForDaughterSafety);
 
   //Cross-check for deliberately negative safeties -- need to kill these tracks
-  if( checkedSafety < 0.0 ){
+  if (checkedSafety < 0.0) {
     fPreemptivelyKillTrack = true;
     G4ThreeVector theDummyVect(0,0,0);
     return theDummyVect;
@@ -1963,7 +1963,7 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                                surfaceNorm );
 
           //Cross-check for deliberately negative safeties -- need to kill these tracks
-          if( the2DSafety < 0.0 ) {
+          if (the2DSafety < 0.0) {
             fPreemptivelyKillTrack = true;
             return 0;
           }
@@ -1977,7 +1977,7 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
           the2DSafety = the2DSafetyAndDir.first;
 
           //Cross-check for deliberately negative safeties -- need to kill these tracks
-          if( the2DSafety < 0.0 ) {
+          if (the2DSafety < 0.0) {
             fPreemptivelyKillTrack = true;
             return 0;
           }
@@ -2049,7 +2049,7 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
         the2DSafety = constrained2DSafety;
 
         //Cross-check for deliberately negative safeties -- need to kill these tracks
-        if( the2DSafety < 0.0 ) {
+        if (the2DSafety < 0.0) {
           fPreemptivelyKillTrack = true;
           return 0;
         }
@@ -2105,7 +2105,7 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
                              false);
 
         //Cross-check for deliberately negative safeties -- need to kill these tracks
-        if( the2DSafety < 0.0 ) {
+        if (the2DSafety < 0.0) {
           fPreemptivelyKillTrack = true;
           return 0;
         }
@@ -2121,7 +2121,7 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
         the2DSafety = the2DSafetyAndDir.first;
 
         //Cross-check for deliberately negative safeties -- need to kill these tracks
-        if( the2DSafety < 0.0 ) {
+        if (the2DSafety < 0.0) {
           fPreemptivelyKillTrack = true;
           return 0;
         }
@@ -2131,7 +2131,7 @@ G4double G4CMPQPDiffusion::GetMeanFreePath(const G4Track& track,
 
     //Cross-check for deliberately negative safeties -- need to kill these tracks
     //This is a bit of a safeguard one -- probably not necessary
-    if( the2DSafety < 0.0 ) {
+    if (the2DSafety < 0.0) {
       fPreemptivelyKillTrack = true;
       return 0;
     }

--- a/library/src/G4CMPQPDiffusionTimeStepperRate.cc
+++ b/library/src/G4CMPQPDiffusionTimeStepperRate.cc
@@ -22,9 +22,5 @@ G4double G4CMPQPDiffusionTimeStepperRate::Rate(const G4Track& /*aTrack*/) const 
 
 void G4CMPQPDiffusionTimeStepperRate::
 UpdateLookupTable(const G4LatticePhysical * /*theLat*/) {
-  G4cout << "In the updateLookupTable function, QPDiffusionTimeStepper. "
-         << "Nothing happens here because this class does not (yet) need a "
-         << "lookup table (but this function is generic to G4CMPVProcesses."
-         << G4endl;
   return;
 }


### PR DESCRIPTION
…h JustWarning blocks, and a killing of the track via returning negative 2D safety from the GeometryUtils functions. I'll note that these errors only occurred rarely, beyond the level of QP diffusion tested found in the validation example. It's possible more FatalException errors are lurking, but now I can go out to 2M pairbreaking energy phonons launched in a complicated qubit geometry and have it run without a fatal exception, which is a good start.