### PR TITLE
G4CMP-597

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-04-22	G4CMP-597 : Make fileCmd optional and provide default value.
+
 2026-02-24  g4cmp-V10-01-01 Multiple bug fixes for G4v11 and new TFR/QP code
 2026-02-20  G4CMP-585 : Fix memory leak from G4CMP-547 ParticleChange mod.
 2026-02-18  G4CMP-588 : Must present NumberOfSecondaries before filling.

--- a/examples/charge/src/ChargeConfigMessenger.cc
+++ b/examples/charge/src/ChargeConfigMessenger.cc
@@ -10,6 +10,7 @@
 //		ChargeConfigManager.
 //
 // 20170816  Michael Kelsey
+// 20260422  G4CMP-597 -- Make fileCmd optional and provide default value.
 
 #include "ChargeConfigMessenger.hh"
 #include "ChargeConfigManager.hh"
@@ -34,6 +35,9 @@ ChargeConfigMessenger::ChargeConfigMessenger(ChargeConfigManager* mgr)
 
   fileCmd = CreateCommand<G4UIcmdWithAString>("EPotFile",
 			      "Set filename for non-uniform electric field");
+  // Make the filename argument optional with empty string as default
+  fileCmd->SetParameterName("filename", true);
+  fileCmd->SetDefaultValue("");
 
   hitsCmd = CreateCommand<G4UIcmdWithAString>("HitsFile",
 			      "Set filename for output of phonon hit locations");


### PR DESCRIPTION
In order to change to UniField, the EPotFile must be set to an empty string. However, when this is attempted the following error occurs.

Illegal parameter (0) </g4cmp/EPotFile> *****

Batch is interrupted!! *****

-------- WWWW ------- G4Exception-START -------- WWWW -------

G4Exception : UIMAN0123
      issued by : G4UImanager::ApplyCommand
Command aborted (400)
Error code : 400

This is just a warning message. ***

WWWW -------- G4Exception-END --------- WWWW -------

To fix this, in the ChargeConfigMessenger.cc, make the fileCmd argument optional, and specify a default value of "" for the argument.