### PR TITLE
G4CMP-593: QP Diffusion Timestepper Parameterization for individual volumes

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-05-08  G4CMP-593 : Add diffusion time stepper tau for individual plattices
 2026-05-06  G4CMP-592 : Replace FatalExceptions in QPDiffusion with warnings
 2026-04-28  G4CMP-496 : Test for zero energy before generating charge pairs.
 2026-04-28  G4CMP-599 : Add track ID and name to G4CMPTrackLimiter output.

--- a/library/include/G4LatticePhysical.hh
+++ b/library/include/G4LatticePhysical.hh
@@ -63,11 +63,12 @@ public:
   // Also includes setting of SC parameters. No longer ambiguous with
   // the previous one
   G4LatticePhysical(const G4LatticeLogical* Lat,
-		    G4double polycrystalElasticScatteringMFP,
-		    G4double scDelta0, G4double scTeff,
-		    G4double scDn,
-		    G4double scQPLocalTrappingTau,		    
-		    G4int h=0, G4int k=0, G4int l=0, G4double rot=0.);
+                    G4double polycrystalElasticScatteringMFP,
+                    G4double scDelta0, G4double scTeff,
+                    G4double scDn,
+                    G4double scQPLocalTrappingTau,
+                    G4double scQPDiffusionStepTau=DBL_MAX,
+                    G4int h=0, G4int k=0, G4int l=0, G4double rot=0.);
 
   
   void SetVerboseLevel(G4int vb) const {
@@ -93,6 +94,7 @@ public:
   void SetSCTeff(G4double val) { fSCTeff = val; }
   void SetSCDn(G4double val) { fSCDn = val; }
   void SetSCQPLocalTrappingTau(G4double val) { fSCQPLocalTrappingTau = val; }
+  void SetSCQPDiffusionStepTau(G4double val) { fSCQPDiffusionStepTau = val; }
 
   // Rotate input vector between lattice and solid orientations
   // Returns new vector value for convenience
@@ -170,6 +172,7 @@ public:
   G4double GetSCTeff() const { return fSCTeff; }
   G4double GetSCDn() const { return fSCDn; }
   G4double GetSCQPLocalTrappingTau() const { return fSCQPLocalTrappingTau; }
+  G4double GetSCQPDiffusionStepTau() const { return fSCQPDiffusionStepTau; }
   
   // Charge carriers have effective mass
   G4double GetHoleMass() const { return fLattice->GetHoleMass(); }
@@ -241,7 +244,8 @@ private:
   G4double fSCTcrit;                         //Critical temp, linked to SCDelta0
   G4double fSCTeff;                          //Effective *QP* temperature
   G4double fSCDn;                            //Normal-state diffusion constant
-  G4double fSCQPLocalTrappingTau;            //Local trapping tau  
+  G4double fSCQPLocalTrappingTau;            //Local trapping tau
+  G4double fSCQPDiffusionStepTau;            //QP Diffusion Stepper Tau
 };
 
 // Write lattice structure to output stream

--- a/library/src/G4CMPParticleChangeForQPDiffusion.cc
+++ b/library/src/G4CMPParticleChangeForQPDiffusion.cc
@@ -44,7 +44,6 @@ UpdateStepForAlongStep(G4Step* pStep) {
 
   //  Update the G4Step specific attributes
   pStep->SetStepLength(theTrueStepLength);
-  theStatusChange = pStep->GetTrack()->GetTrackStatus();
 
   //Debugging
   if (verboseLevel > 2) {

--- a/library/src/G4CMPQPDiffusion.cc
+++ b/library/src/G4CMPQPDiffusion.cc
@@ -796,7 +796,9 @@ G4VParticleChange* G4CMPQPDiffusion::AlongStepDoIt(const G4Track& track,
               << " All tries exhausted, which suggests this is perhaps a more "
               << "fundamental issue with G4CMP, or maybe your geometry is just "
               << "not following the recommended rules for tracked film "
-              << "response. Killing Track.";
+              << "response. Killing Track. fOldPosition: "
+              << fOldPosition << ", fNewPosition: " << fNewPosition
+              << " after nsteps: " << track.GetCurrentStepNumber();
           G4Exception("G4CMPQPDiffusion::AlongStepDoIt", "QPDiffusion006",
                       JustWarning, amg);
 

--- a/library/src/G4CMPQPDiffusion.cc
+++ b/library/src/G4CMPQPDiffusion.cc
@@ -792,9 +792,9 @@ G4VParticleChange* G4CMPQPDiffusion::AlongStepDoIt(const G4Track& track,
               << " All tries exhausted, which suggests this is perhaps a more "
               << "fundamental issue with G4CMP, or maybe your geometry is just "
               << "not following the recommended rules for tracked film "
-              << "response. Killing Track. fOldPosition: "
-              << fOldPosition << ", fNewPosition: " << fNewPosition
-              << " after nsteps: " << track.GetCurrentStepNumber();
+              << "response. Killing Track." << G4endl << "fOldPosition: "
+              << fOldPosition << G4endl << "fNewPosition: " << fNewPosition
+              << G4endl << ", after nsteps: " << track.GetCurrentStepNumber();
           G4Exception("G4CMPQPDiffusion::AlongStepDoIt", "QPDiffusion006",
                       JustWarning, amg);
 

--- a/library/src/G4CMPQPDiffusionTimeStepperRate.cc
+++ b/library/src/G4CMPQPDiffusionTimeStepperRate.cc
@@ -8,15 +8,16 @@
 //  diffusion
 //
 #include "G4CMPQPDiffusionTimeStepperRate.hh"
+#include "G4LatticePhysical.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4Track.hh"
 #include <vector>
 #include <map>
 
-G4double G4CMPQPDiffusionTimeStepperRate::Rate(const G4Track& /*aTrack*/) const {
-
+G4double G4CMPQPDiffusionTimeStepperRate::Rate(const G4Track& /*aTrack*/) const {  
+  G4double tau_nextScatter = theLattice->GetSCQPDiffusionStepTau();
   //Compute tau for time stepper, and invert for rate
-  double tau_nextScatter = 100000 * CLHEP::ns; //Temporarily hardcoded
+  //double tau_nextScatter = 100000 * CLHEP::ns; //Temporarily hardcoded
   return (1.0/tau_nextScatter);
 }
 

--- a/library/src/G4CMPQPDiffusionTimeStepperRate.cc
+++ b/library/src/G4CMPQPDiffusionTimeStepperRate.cc
@@ -14,18 +14,13 @@
 #include <vector>
 #include <map>
 
-G4double G4CMPQPDiffusionTimeStepperRate::Rate(const G4Track& /*aTrack*/) const {  
-  G4double tau_nextScatter = theLattice->GetSCQPDiffusionStepTau();
+G4double G4CMPQPDiffusionTimeStepperRate::Rate(const G4Track& /*aTrack*/) const {
   //Compute tau for time stepper, and invert for rate
-  //double tau_nextScatter = 100000 * CLHEP::ns; //Temporarily hardcoded
+  G4double tau_nextScatter = theLattice->GetSCQPDiffusionStepTau();
   return (1.0/tau_nextScatter);
 }
 
 void G4CMPQPDiffusionTimeStepperRate::
 UpdateLookupTable(const G4LatticePhysical * /*theLat*/) {
-  G4cout << "In the updateLookupTable function, QPDiffusionTimeStepper. "
-         << "Nothing happens here because this class does not (yet) need a "
-         << "lookup table (but this function is generic to G4CMPVProcesses."
-         << G4endl;
   return;
 }

--- a/library/src/G4LatticePhysical.cc
+++ b/library/src/G4LatticePhysical.cc
@@ -53,7 +53,7 @@ G4LatticePhysical::G4LatticePhysical()
   : verboseLevel(0), fLattice(0), hMiller(0), kMiller(0), lMiller(0),
     fRot(0.), fTemperature(-1.), fPolycrystalElasticScatteringMFP(DBL_MAX),
     fSCDelta0(0.), fSCTcrit(0.), fSCTeff(0.), fSCDn(0.),
-    fSCQPLocalTrappingTau(DBL_MAX), fSCQPdiffusionStepTau(DBL_MAX) {;}
+    fSCQPLocalTrappingTau(DBL_MAX), fSCQPDiffusionStepTau(DBL_MAX) {;}
 
 // Set lattice orientation (relative to G4VSolid) with Miller indices
 

--- a/library/src/G4LatticePhysical.cc
+++ b/library/src/G4LatticePhysical.cc
@@ -53,7 +53,7 @@ G4LatticePhysical::G4LatticePhysical()
   : verboseLevel(0), fLattice(0), hMiller(0), kMiller(0), lMiller(0),
     fRot(0.), fTemperature(-1.), fPolycrystalElasticScatteringMFP(DBL_MAX),
     fSCDelta0(0.), fSCTcrit(0.), fSCTeff(0.), fSCDn(0.),
-    fSCQPLocalTrappingTau(DBL_MAX) {;}
+    fSCQPLocalTrappingTau(DBL_MAX), fSCQPdiffusionStepTau(DBL_MAX) {;}
 
 // Set lattice orientation (relative to G4VSolid) with Miller indices
 
@@ -61,7 +61,8 @@ G4LatticePhysical::G4LatticePhysical(const G4LatticeLogical* Lat,
 				     G4int h, G4int k, G4int l, G4double rot)
   : verboseLevel(0), fLattice(Lat), fTemperature(-1.),
     fPolycrystalElasticScatteringMFP(DBL_MAX), fSCDelta0(0.), fSCTcrit(0.),
-    fSCTeff(0.), fSCDn(0.), fSCQPLocalTrappingTau(DBL_MAX) {
+    fSCTeff(0.), fSCDn(0.), fSCQPLocalTrappingTau(DBL_MAX),
+    fSCQPDiffusionStepTau(DBL_MAX) {
 
   //Use the set delta0 to set a Tcrit via BCS
   
@@ -73,15 +74,17 @@ G4LatticePhysical::G4LatticePhysical(const G4LatticeLogical* Lat,
 // of the lattice without requiring the h, k, l, and rot parameters
 
 G4LatticePhysical::G4LatticePhysical(const G4LatticeLogical* Lat,
-				     G4double polycrystalElasticScatteringMFP,
-				     G4double scDelta0, G4double scTeff,
-				     G4double scDn,
-				     G4double scQPLocalTrappingTau,
-				     G4int h, G4int k, G4int l, G4double rot)
+                                     G4double polycrystalElasticScatteringMFP,
+                                     G4double scDelta0, G4double scTeff,
+                                     G4double scDn,
+                                     G4double scQPLocalTrappingTau,
+                                     G4double scQPDiffusionStepTau,
+                                     G4int h, G4int k, G4int l, G4double rot)
   : verboseLevel(0), fLattice(Lat), fTemperature(-1.),
     fPolycrystalElasticScatteringMFP(polycrystalElasticScatteringMFP),
     fSCDelta0(scDelta0), fSCTcrit(scDelta0 / CLHEP::k_Boltzmann / 1.764),    
-    fSCTeff(scTeff), fSCDn(scDn), fSCQPLocalTrappingTau(scQPLocalTrappingTau) {
+    fSCTeff(scTeff), fSCDn(scDn), fSCQPLocalTrappingTau(scQPLocalTrappingTau),
+    fSCQPDiffusionStepTau(scQPDiffusionStepTau){
 
   //Use the set delta0 to set a Tcrit via BCS
   


### PR DESCRIPTION
Adding functionality to allow parameterizing the QP diffusion timestepper process for individual physical lattices.