### PR TITLE
G4CMP-604

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -8,6 +8,7 @@ ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 Development Project for G4CMP-515
 2026-05-06  G4CMP-515 : Expand charge reflection for both specular and diffuse.
+2026-05-08	G4CMP-604 : Add surface property UI commands to charge example.
 2026-05-07  G4CMP-603 : Use correct probability for charge specular reflection.
 2026-05-02  G4CMP-602 : Fix parentheses in MapV_elToP, to avoid NaNs.
 2026-03-27  G4CMP-595 : Add preprocessor flag for use of charge reflection.

--- a/examples/charge/include/ChargeConfigManager.hh
+++ b/examples/charge/include/ChargeConfigManager.hh
@@ -15,6 +15,7 @@
 //		changed via macro commands (see ChargeConfigMessenger).
 //
 // 20170816  M. Kelsey -- Extract hit filename from G4CMPConfigManager.
+// 20260513  G4CMP-604 -- Add surface property UI commands to charge example.
 
 #include "globals.hh"
 
@@ -34,6 +35,8 @@ public:
   static G4int GetMillerH()		 { return Instance()->millerH; }
   static G4int GetMillerK()		 { return Instance()->millerK; }
   static G4int GetMillerL()		 { return Instance()->millerL; }
+  static G4double GetChargeAbsorbProb()    { return Instance()->chargeAbsorbProb; }
+  static G4double GetSpecularReflectProb() { return Instance()->specularReflectProb; }
 
   static void GetMillerOrientation(G4int& h, G4int& k, G4int& l) {
     h = Instance()->millerH; k = Instance()->millerK; l = Instance()->millerL;
@@ -52,6 +55,10 @@ public:
     { Instance()->millerH=h; Instance()->millerK=k, Instance()->millerL=l;
       UpdateGeometry();
     }
+  static void SetChargeAbsorbProb(G4double value)
+    { Instance()->chargeAbsorbProb = value; UpdateGeometry(); }
+  static void SetSpecularReflectProb(G4double value)
+    { Instance()->specularReflectProb = value; UpdateGeometry(); }
 
   static void UpdateGeometry();
 
@@ -72,6 +79,8 @@ private:
   G4int millerH;	// Lattice orientation ($G4CMP_MILLER_H,_K,_L)
   G4int millerK;
   G4int millerL;
+  G4double chargeAbsorbProb;	// Charge absorption probability at surfaces
+  G4double specularReflectProb;	// Specular reflection probability at surfaces
 
   ChargeConfigMessenger* messenger;
 };

--- a/examples/charge/include/ChargeConfigMessenger.hh
+++ b/examples/charge/include/ChargeConfigMessenger.hh
@@ -13,6 +13,7 @@
 //		ChargeConfigManager.
 //
 // 20170816  Michael Kelsey
+// 20260513  G4CMP-604 -- Add surface property UI commands to charge example.
 
 #include "G4UImessenger.hh"
 
@@ -36,7 +37,9 @@ private:
   G4UIcmdWithADouble* escaleCmd;
   G4UIcmdWithAString* fileCmd;
   G4UIcmdWithAString* hitsCmd;
-  G4UIcmdWithAString* millerCmd;	// Will parse out three integers
+  G4UIcmdWithAString* millerCmd;    // Will parse out three integers
+  G4UIcmdWithADouble* absorbCmd;    // /g4cmp/chargeAbsorb
+  G4UIcmdWithADouble* specularCmd;  // /g4cmp/specularReflect
 
 private:
   ChargeConfigMessenger(const ChargeConfigMessenger&);	// Copying is forbidden

--- a/examples/charge/include/ChargeDetectorConstruction.hh
+++ b/examples/charge/include/ChargeDetectorConstruction.hh
@@ -7,6 +7,7 @@
 //
 // 20160904  Add electrode pattern to surface configuration
 // 20170721  Surface property owns electrode pattern, deletes at end
+// 20260513  G4CMP-604 -- Add surface property UI commands to charge example.
 
 #ifndef ChargeDetectorConstruction_h
 #define ChargeDetectorConstruction_h 1
@@ -51,6 +52,8 @@ private:
   G4double zipThickness; // Useful for geom. and field
   G4double epotScale;
   G4double voltage;
+  G4double chargeAbsorbProb;
+  G4double specularReflectProb;
   G4bool constructed;
   G4String epotFileName;
   G4String outputFileName;

--- a/examples/charge/src/ChargeConfigManager.cc
+++ b/examples/charge/src/ChargeConfigManager.cc
@@ -12,6 +12,7 @@
 //		changed via macro commands (see ChargeConfigMessenger).
 //
 // 20170816  M. Kelsey -- Extract hit filename from G4CMPConfigManager.
+// 20260513  G4CMP-604 -- Add surface property UI commands to charge example.
 
 #include "ChargeConfigManager.hh"
 #include "ChargeConfigMessenger.hh"
@@ -35,6 +36,8 @@ ChargeConfigManager::ChargeConfigManager()
     EPot_file(getenv("G4CMP_EPOT_FILE")?getenv("G4CMP_EPOT_FILE"):""),
     Hit_file(getenv("G4CMP_HIT_FILE")?getenv("G4CMP_HIT_FILE"):"charge_hits.txt"),
     millerH(0), millerK(0), millerL(0),
+    chargeAbsorbProb(getenv("G4CMP_CHARGE_ABSORB")?strtod(getenv("G4CMP_CHARGE_ABSORB"),0):1e-5),
+    specularReflectProb(getenv("G4CMP_SPECULAR_REFLECT")?strtod(getenv("G4CMP_SPECULAR_REFLECT"),0):0.5),
     messenger(new ChargeConfigMessenger(this)) {;}
 
 ChargeConfigManager::~ChargeConfigManager() {
@@ -46,4 +49,26 @@ ChargeConfigManager::~ChargeConfigManager() {
 
 void ChargeConfigManager::UpdateGeometry() {
   G4RunManager::GetRunManager()->ReinitializeGeometry(true);
+}
+
+// Getters (static access for convenience, like other params)
+
+G4double ChargeConfigManager::GetChargeAbsorbProb() {
+  return Instance()->chargeAbsorbProb;
+}
+
+G4double ChargeConfigManager::GetSpecularReflectProb() {
+  return Instance()->specularReflectProb;
+}
+
+// Setters (update geometry so changes take effect on re-initialization)
+
+void ChargeConfigManager::SetChargeAbsorbProb(G4double val) {
+  chargeAbsorbProb = val;
+  UpdateGeometry();
+}
+
+void ChargeConfigManager::SetSpecularReflectProb(G4double val) {
+  specularReflectProb = val;
+  UpdateGeometry();
 }

--- a/examples/charge/src/ChargeConfigMessenger.cc
+++ b/examples/charge/src/ChargeConfigMessenger.cc
@@ -11,6 +11,7 @@
 //
 // 20170816  Michael Kelsey
 // 20260422  G4CMP-597 -- Make fileCmd optional and provide default value.
+// 20260513  G4CMP-604 -- Add surface property UI commands to charge example.
 
 #include "ChargeConfigMessenger.hh"
 #include "ChargeConfigManager.hh"
@@ -25,7 +26,7 @@
 ChargeConfigMessenger::ChargeConfigMessenger(ChargeConfigManager* mgr)
   : G4UImessenger("/g4cmp/", "User configuration for G4CMP phonon example"),
     theManager(mgr), voltageCmd(0), escaleCmd(0), fileCmd(0), hitsCmd(0),
-    millerCmd(0) {
+    millerCmd(0), absorbCmd(0), specularCmd(0) {
   voltageCmd = CreateCommand<G4UIcmdWithADoubleAndUnit>("voltage",
 				"Set voltage for uniform electric field");
   voltageCmd->SetUnitCategory("Electric potential");
@@ -45,6 +46,12 @@ ChargeConfigMessenger::ChargeConfigMessenger(ChargeConfigManager* mgr)
   millerCmd = CreateCommand<G4UIcmdWithAString>("orientation",
 	"Lattice orientation (Miller indices h, k, l in direct basis)");
   millerCmd->SetGuidance("Orientation aligns with Z axis of G4VSolid");
+
+  absorbCmd = CreateCommand<G4UIcmdWithADouble>("chargeAbsorb",
+		"Set probability (0-1) for charge carriers to be absorbed at detector surfaces (top, bottom, sidewalls)");
+
+  specularCmd = CreateCommand<G4UIcmdWithADouble>("specularReflect",
+		"Set probability (0-1) for specular reflection of charge carriers at detector surfaces (top, bottom, sidewalls)");
 }
 
 
@@ -54,6 +61,8 @@ ChargeConfigMessenger::~ChargeConfigMessenger() {
   delete fileCmd; fileCmd=0;
   delete hitsCmd; hitsCmd=0;
   delete millerCmd; millerCmd=0;
+  delete absorbCmd; absorbCmd=0;
+  delete specularCmd; specularCmd=0;
 }
 
 
@@ -73,4 +82,11 @@ void ChargeConfigMessenger::SetNewValue(G4UIcommand* cmd, G4String value) {
     G4Tokenizer split(value);
     theManager->SetMillerOrientation(StoI(split()),StoI(split()),StoI(split()));
   }
+
+  if (cmd == absorbCmd)
+    theManager->SetChargeAbsorbProb(absorbCmd->GetNewDoubleValue(value));
+
+  if (cmd == specularCmd)
+    theManager->SetSpecularReflectProb(specularCmd->GetNewDoubleValue(value));
+}
 }

--- a/examples/charge/src/ChargeDetectorConstruction.cc
+++ b/examples/charge/src/ChargeDetectorConstruction.cc
@@ -10,7 +10,8 @@
 // 20170816  Field configuration parameters moved to local configuration
 // 20211207  Replace G4Logical*Surface with G4CMP-specific versions.
 // 20251117  G4CMP-541 -- For G4 v11, replace ::Invisible w/::GetInvisible()
-// 20260112  G4CMP-514: Modify G4CMPSurfaceProperty for specular reflection.
+// 20260112  G4CMP-514 -- Modify G4CMPSurfaceProperty for specular reflection.
+// 20260513  G4CMP-604 -- Add surface property UI commands to charge example.
 
 #include "ChargeDetectorConstruction.hh"
 #include "ChargeConfigManager.hh"
@@ -49,7 +50,8 @@ ChargeDetectorConstruction::ChargeDetectorConstruction() :
   fEMField(nullptr), liquidHelium(nullptr), germanium(nullptr),
   aluminum(nullptr), tungsten(nullptr), worldPhys(nullptr),
   zipThickness(2.54*cm), epotScale(0.), voltage(0.), constructed(false),
-  epotFileName(""), outputFileName("")
+  epotFileName(""), outputFileName(""),
+  chargeAbsorbProb(0.), specularReflectProb(0.)
 {
   /* Default initialization does not leave object in usable state.
    * Doesn't matter because run initialization will call Construct() and all
@@ -89,6 +91,14 @@ G4VPhysicalVolume* ChargeDetectorConstruction::Construct()
       if (sensitivity) sensitivity->SetOutputFile(outputFileName);
     }
 
+    // Check for changes in surface probabilities (new)
+    if (chargeAbsorbProb != ChargeConfigManager::GetChargeAbsorbProb() ||
+        specularReflectProb != ChargeConfigManager::GetSpecularReflectProb()) {
+      delete topSurfProp; topSurfProp = nullptr;
+      delete botSurfProp; botSurfProp = nullptr;
+      delete wallSurfProp; wallSurfProp = nullptr;
+    }
+
     // Have to completely remove all lattices to avoid warning on reconstruction
     latManager->Reset();
     // Clear all LogicalSurfaces; no need to redfine SurfaceProperty
@@ -101,6 +111,8 @@ G4VPhysicalVolume* ChargeDetectorConstruction::Construct()
   epotScale = ChargeConfigManager::GetEPotScale();
   epotFileName = ChargeConfigManager::GetEPotFile();
   outputFileName = ChargeConfigManager::GetHitOutput();
+  chargeAbsorbProb = ChargeConfigManager::GetChargeAbsorbProb();
+  specularReflectProb = ChargeConfigManager::GetSpecularReflectProb();
 
   DefineMaterials();
   SetupGeometry();
@@ -185,39 +197,39 @@ void ChargeDetectorConstruction::SetupGeometry()
   // Define surface properties. Only should be done once
   if (!constructed) {
     topSurfProp = new G4CMPSurfaceProperty("topSurfProp",
-                                           1e-5,  // Prob. to absorb charge
-                                           1.,    // If not absorbed, prob to reflect charge
-                                           0.5,   // Prob of charge specular reflection (optional)
-                                           0.,    // Min wave number to absorb electron
-                                           0.,    // Min wave number to absorb hole
-                                           0.22,  // Prob. to absorb phonon
-                                           1.,    // If not absorbed, prob to reflect phonon
-                                           0.,    // Prob. of phonon specular reflection
-                                           0.);   // Min wave number to absorb phonon
+                                           chargeAbsorbProb,      // Prob. to absorb charge
+                                           1.,                    // If not absorbed, prob to reflect charge
+                                           specularReflectProb,   // Prob of charge specular reflection (optional)
+                                           0.,                    // Min wave number to absorb electron
+                                           0.,                    // Min wave number to absorb hole
+                                           0.22,                  // Prob. to absorb phonon
+                                           1.,                    // If not absorbed, prob to reflect phonon
+                                           0.,                    // Prob. of phonon specular reflection
+                                           0.);                   // Min wave number to absorb phonon
     topSurfProp->SetChargeElectrode(new ChargeElectrodePattern);
 
     botSurfProp = new G4CMPSurfaceProperty("botSurfProp",
-                                           1e-5,  // Prob. to absorb charge
-                                           1.,    // If not absorbed, prob to reflect charge
-                                           0.5,   // Prob of charge specular reflection (optional)
-                                           0.,    // Min wave number to absorb electron
-                                           0.,    // Min wave number to absorb hole
-                                           0.22,  // Prob. to absorb phonon
-                                           1.,    // If not absorbed, prob to reflect phonon
-                                           0.,    // Prob. of phonon specular reflection
-                                           0.);   // Min wave number to absorb phonon
+                                           chargeAbsorbProb,      // Prob. to absorb charge
+                                           1.,                    // If not absorbed, prob to reflect charge
+                                           specularReflectProb,   // Prob of charge specular reflection (optional)
+                                           0.,                    // Min wave number to absorb electron
+                                           0.,                    // Min wave number to absorb hole
+                                           0.22,                  // Prob. to absorb phonon
+                                           1.,                    // If not absorbed, prob to reflect phonon
+                                           0.,                    // Prob. of phonon specular reflection
+                                           0.);                   // Min wave number to absorb phonon
     botSurfProp->SetChargeElectrode(new ChargeElectrodePattern);
 
     wallSurfProp = new G4CMPSurfaceProperty("wallSurfProp",
-                                           1e-5,  // Prob. to absorb charge
-                                           1.,    // If not absorbed, prob to reflect charge
-                                           0.5,   // Prob of charge specular reflection (optional)
-                                           0.,    // Min wave number to absorb electron
-                                           0.,    // Min wave number to absorb hole
-                                           0.,    // Prob. to absorb phonon
-                                           1.,    // If not absorbed, prob to reflect phonon
-                                           0.,    // Prob. of phonon specular reflection
-                                           0.);   // Min wave number to absorb phonon
+                                           chargeAbsorbProb,      // Prob. to absorb charge
+                                           1.,                    // If not absorbed, prob to reflect charge
+                                           specularReflectProb,   // Prob of charge specular reflection (optional)
+                                           0.,                    // Min wave number to absorb electron
+                                           0.,                    // Min wave number to absorb hole
+                                           0.,                    // Prob. to absorb phonon
+                                           1.,                    // If not absorbed, prob to reflect phonon
+                                           0.,                    // Prob. of phonon specular reflection
+                                           0.);                   // Min wave number to absorb phonon
   }
 
   // Add surfaces between Ge-Al, and Ge-World


### PR DESCRIPTION
It would be useful to add a macro command to examples/charge to allow setting the specular reflection probability. Right now, it's hardcoded to 0.5 in examples/charge/src/ChargeDetectorConstruction.cc, for all three surfaces (top, bottom, and sidewalls). I propose making that parameter a data member of ChargeConfigManager, and adding a /g4cmp/specularReflection UI command to ChargeConfigMessenger. Then ChargeDetectorConstruction can query the config for the value to be used.

We should probably also add a UI command and parameter for charge absorption probability, also to be used on all surfaces. Right now, it's hardcoded as 1e-5, which lets you test bounces out to very large values. I can imagine users wanting instead to test recombination or other things, and wanting the absorption to happen sooner.