### PR TITLE
G4CMP-619: Softening a few exceptions in Boundary/GeometryUtils from Fatal Exceptions to less extreme types.

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-06-01  G4CMP-619 : Softened some exception types in Boundary/GeometryUtils
+
 2026-05-28  g4cmp-V10-02-00 Several bug fixes and EnergyPartition improvements
 2026-05-28  G4CMP-617 : Simplify nParticlesMinimum tests in EnergyPartition
 2026-05-23  G4CMP-608 : Address initializer compiler warnings from G4CMP-598.

--- a/library/src/G4CMPBoundaryUtils.cc
+++ b/library/src/G4CMPBoundaryUtils.cc
@@ -558,7 +558,7 @@ G4bool G4CMPBoundaryUtils::CheckStepBoundary(const G4Step& aStep,
         //it's in the local coordinate system)
         if (preSolid->Inside(surfacePoint) != kSurface) {
           G4Exception((procName+"::CheckStepBoundary").c_str(),
-                      "Boundary006", FatalException /*EventMustBeAborted*/,
+                      "Boundary006", EventMustBeAborted,
                       "Boundary-limited step cannot find boundary surface point"
                       );
           return false;

--- a/library/src/G4CMPGeometryUtils.cc
+++ b/library/src/G4CMPGeometryUtils.cc
@@ -980,7 +980,7 @@ G4ThreeVector G4CMP::GetSurfaceNormal(const G4Step& step, const G4ThreeVector& i
         << "Volumes are: "
         << preSolid->GetName() << " and " << postSolid->GetName() << G4endl;
     G4Exception("G4CMP::GetSurfaceNormal()", "Geometry006",
-                FatalException, msg);
+                JustWarning, msg);
     G4ThreeVector dummy(0,0,0);
     output = dummy;
   }


### PR DESCRIPTION
Updated a few exceptions in GeometryUtils and BoundaryUtils from FatalException to either EventMustBeAborted or JustWarning. 

Did not change ALL of the exceptions in Boundary/GeometryUtils -- there are a handful in GeometryUtils that are specifically applicable to 2D diffusion, that I'd like to keep fatal for now since they shouldn't be a blocker for SCDMS as much as the other ones I have touched here are.